### PR TITLE
Add deep replay and request debug tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,23 @@ Jidoka.inspect(MyApp.TimeAgent)
   Jidoka.preflight(MyApp.TimeAgent, "What time is it in Chicago?")
 
 preflight.prompt.messages
-preflight.prompt.tools
+preflight.prompt.tool_definitions
 ```
 
 `preflight/3` validates the prompt and tool metadata without calling a model.
+
+After a turn, use `Jidoka.Debug.request/2` when you need the full request view
+for a user report, notebook, or test:
+
+```elixir
+{:ok, result} = Jidoka.turn(MyApp.TimeAgent, "What time is it in Chicago?")
+{:ok, summary} = Jidoka.Debug.request(result)
+
+summary.prompt.messages
+summary.operation_results
+summary.usage
+summary.replay_diagnostics.status
+```
 
 ## Author With Data
 
@@ -251,6 +264,7 @@ Start here:
 - [Workflows](guides/workflows.md)
 - [Controls](guides/controls.md)
 - [Sessions And Stores](guides/sessions-and-stores.md)
+- [Inspection And Preflight](guides/inspection-and-preflight.md)
 - [Testing And Evals](guides/testing-and-evals.md)
 
 Useful next topics:

--- a/guides/inspection-and-preflight.md
+++ b/guides/inspection-and-preflight.md
@@ -255,7 +255,9 @@ summary.replay_diagnostics.status
 
 The summary is data-only. It does not call an LLM, tool, memory store, or
 runtime capability. For sessions, use `Jidoka.Debug.latest(session)` or pass
-`request_id:` when you need a specific hibernated request.
+`request_id:` when you need a specific hibernated request. Unknown request ids
+return `{:error, {:request_debug_not_found, session_id, request_id}}` instead
+of falling back to the latest request.
 
 ### Step 7: Inspect A Snapshot Or Session
 

--- a/guides/inspection-and-preflight.md
+++ b/guides/inspection-and-preflight.md
@@ -253,11 +253,46 @@ summary.replay_diagnostics.status
 #=> :complete
 ```
 
+The summary is a typed `Jidoka.Debug.RequestSummary`:
+
+```elixir
+%Jidoka.Debug.RequestSummary{
+  request_id: "turn_...",
+  agent_id: "time_agent",
+  status: :finished,
+  model: "openai:gpt-4o-mini",
+  input: "What time is it?",
+  content: "It is 09:30 in Chicago.",
+  context_keys: [],
+  operation_names: ["local_time"],
+  usage: %{llm_calls: 2, total_tokens: 184},
+  replay_diagnostics: %Jidoka.Debug.ReplayDiagnostics{status: :complete}
+}
+```
+
 The summary is data-only. It does not call an LLM, tool, memory store, or
 runtime capability. For sessions, use `Jidoka.Debug.latest(session)` or pass
 `request_id:` when you need a specific hibernated request. Unknown request ids
 return `{:error, {:request_debug_not_found, session_id, request_id}}` instead
 of falling back to the latest request.
+
+For hibernated snapshots and sessions, the same call exposes pending review
+data and incomplete effects:
+
+```elixir
+{:hibernate, session, snapshot} = Jidoka.Session.run(session, "Refund A1001")
+
+{:ok, summary} = Jidoka.Debug.request(snapshot, session: session)
+
+summary.status
+#=> :waiting
+
+summary.pending_reviews
+#=> [%{operation: "refund_order", ...}]
+
+summary.replay_diagnostics.status
+#=> :waiting
+```
 
 ### Step 7: Inspect A Snapshot Or Session
 
@@ -294,6 +329,15 @@ Replay diagnostics explain whether recorded effect data is complete:
 diagnostics.status
 #=> :complete | :waiting | :failed | :incomplete
 ```
+
+Status meanings:
+
+| Status | Meaning |
+| --- | --- |
+| `:complete` | Every recorded effect intent has a result. |
+| `:waiting` | A human review request is still pending. |
+| `:failed` | An effect result or timeline event failed. |
+| `:incomplete` | At least one effect intent has no recorded result. |
 
 ### Step 8: Use Inspect For Logging
 

--- a/guides/inspection-and-preflight.md
+++ b/guides/inspection-and-preflight.md
@@ -104,6 +104,7 @@ The three functions cover three layers of the data-first runtime.
 | "How does this turn input shape the prompt?" | `Jidoka.preflight(agent, input)` | yes |
 | "What is the deterministic projection of this value?" | `Jidoka.project(value)` | yes |
 | "What happened during the turn that just ran?" | `Jidoka.inspect(turn_result)` | yes |
+| "Debug the exact request that just ran." | `Jidoka.Debug.request(turn_result)` | yes |
 | "Replay this snapshot." | `Jidoka.resume(snapshot, opts)` | no, runs effects |
 
 ## How To
@@ -232,7 +233,31 @@ projected.journal.intent_count
 `Jidoka.inspect(result)` returns a richer map with a `:timeline` and
 `:status` already filled in - useful for log output during development.
 
-### Step 6: Inspect A Snapshot Or Session
+### Step 6: Debug A Completed Request
+
+`Jidoka.Debug.request/2` assembles one request-level view from a result,
+session, snapshot, or replay. Use it when you want the prompt, operation
+calls, usage, timeline, journal, and replay diagnostics in one place.
+
+```elixir
+{:ok, result} = Jidoka.turn(MyApp.TimeAgent, "What time is it?", llm: llm)
+
+{:ok, summary} = Jidoka.Debug.request(result)
+
+summary.request_id
+summary.prompt.messages
+summary.operation_names
+summary.operation_results
+summary.usage
+summary.replay_diagnostics.status
+#=> :complete
+```
+
+The summary is data-only. It does not call an LLM, tool, memory store, or
+runtime capability. For sessions, use `Jidoka.Debug.latest(session)` or pass
+`request_id:` when you need a specific hibernated request.
+
+### Step 7: Inspect A Snapshot Or Session
 
 When a turn hibernates (typically because an operation control
 returned `{:interrupt, _}`), `inspect/2` produces a snapshot view that
@@ -258,7 +283,17 @@ count, pending reviews, and the latest cursor. Sessions are documented in
 [Runtime And Harness](runtime-and-harness.md); the inspection view is the
 debugging entry point for them.
 
-### Step 7: Use Inspect For Logging
+Replay diagnostics explain whether recorded effect data is complete:
+
+```elixir
+{:ok, replay} = Jidoka.Session.replay(session)
+{:ok, diagnostics} = Jidoka.Harness.Replay.diagnose(replay)
+
+diagnostics.status
+#=> :complete | :waiting | :failed | :incomplete
+```
+
+### Step 8: Use Inspect For Logging
 
 Because every view is a plain map, it serializes cleanly:
 
@@ -281,6 +316,9 @@ production traces; `inspect/2` is the developer view.
 - **Snapshot views in failure logs.** When a session hibernates, log the
   result of `Jidoka.inspect(snapshot)`; the timeline plus pending review
   data is usually enough to diagnose stuck approvals.
+- **Request summaries for user reports.** When a user says "that answer was
+  wrong", capture `Jidoka.Debug.request(result)` so you have the prompt,
+  operation results, usage, and replay diagnostics together.
 - **Compare DSL and imported specs.** `Jidoka.inspect(dsl_module).spec ==
   Jidoka.inspect(imported_spec).spec` is the simplest parity assertion.
 - **Inspect workflow modules before agent prompts.** If the workflow graph or
@@ -344,6 +382,8 @@ less between releases.
   `prompt`, `events`, `timeline`, `diagnostics`.
 - [`Jidoka.Projection`](`Jidoka.Projection`) - the data-facing companion
   used by `Jidoka.project/1`.
+- [`Jidoka.Debug`](`Jidoka.Debug`) - request-level summaries and replay
+  diagnostics.
 - [`Jidoka.Agent.Spec`](`Jidoka.Agent.Spec`) - the spec inspect views
   path.
 

--- a/guides/kino-notebooks.md
+++ b/guides/kino-notebooks.md
@@ -248,6 +248,11 @@ summary.replay_diagnostics.status
 
 Use this after a live call when you need to see the assembled prompt,
 operation results, usage, timeline, and replay diagnostics in one place.
+For a session, pass `request_id:` when you need a specific stored request:
+
+```elixir
+{:ok, summary} = Jidoka.Kino.debug_request(session, request_id: "turn_...")
+```
 
 ### Step 8: Start An Agent Once Per Notebook Session
 
@@ -265,7 +270,7 @@ the existing pid instead.
 The second cell evaluation returns the same pid without restarting the
 process, which keeps any in-memory session state intact.
 
-### Step 8: Render Context Maps Without Leaking Internals
+### Step 9: Render Context Maps Without Leaking Internals
 
 `context/3` separates the public and internal halves of a runtime context
 map and renders them as two tables.

--- a/guides/kino-notebooks.md
+++ b/guides/kino-notebooks.md
@@ -7,8 +7,9 @@ no-op rendering boundary outside Livebook. The helpers are thin wrappers
 around stable Jidoka contracts (`Jidoka.inspect/1`, `Jidoka.preflight/3`,
 `Jidoka.Harness`, `Jidoka.Turn.Result`). By the end you will be able to set up
 a notebook, mirror Livebook provider secrets, debug an agent definition,
-render a preflight, run a chat cell deterministically, and start an agent
-process that survives notebook re-evaluation.
+debug a completed request, render a preflight, run a chat cell
+deterministically, and start an agent process that survives notebook
+re-evaluation.
 
 ## When To Use This
 
@@ -229,7 +230,26 @@ The wrapped result is returned unchanged. Pair with
 `Jidoka.Kino.timeline/2` or `Jidoka.Kino.call_graph/2` when you want a
 separate cell to inspect the same data later.
 
-### Step 7: Start An Agent Once Per Notebook Session
+### Step 7: Debug A Completed Request
+
+`debug_request/2` renders the exact request-level summary for a result,
+session, snapshot, or replay.
+
+```elixir
+{:ok, result} =
+  Jidoka.turn(MyApp.TimeAgent, "What time is it in Chicago?", llm: deterministic_llm())
+
+{:ok, summary} = Jidoka.Kino.debug_request(result)
+
+summary.prompt.messages
+summary.operation_results
+summary.replay_diagnostics.status
+```
+
+Use this after a live call when you need to see the assembled prompt,
+operation results, usage, timeline, and replay diagnostics in one place.
+
+### Step 8: Start An Agent Once Per Notebook Session
 
 Plain `MyApp.TimeAgent.start(id: "demo")` raises on the second cell
 evaluation because the id is already registered. `start_or_reuse/3` returns

--- a/guides/runtime-and-harness.md
+++ b/guides/runtime-and-harness.md
@@ -92,6 +92,30 @@ Replay is a projection over stored data, not a runtime call:
 replay.timeline
 ```
 
+Replay diagnostics explain whether recorded effects are complete and safe to
+reason about without calling providers or tools:
+
+```elixir
+{:ok, diagnostics} = Jidoka.Harness.Replay.diagnose(replay)
+
+diagnostics.status
+#=> :complete | :waiting | :failed | :incomplete
+
+diagnostics.missing_effect_results
+diagnostics.unsafe_effects
+diagnostics.pending_reviews
+```
+
+Use `Jidoka.Debug.request/2` when you want a request-level view that combines
+prompt metadata, operation results, usage, timeline, journal, and replay
+diagnostics:
+
+```elixir
+{:ok, summary} = Jidoka.Debug.request(result)
+summary.prompt.messages
+summary.replay_diagnostics.status
+```
+
 ## Observability And Evals
 
 Core runtime events are neutral `Jidoka.Event` data. `Jidoka.Trace` projects

--- a/guides/runtime-and-harness.md
+++ b/guides/runtime-and-harness.md
@@ -106,6 +106,15 @@ diagnostics.unsafe_effects
 diagnostics.pending_reviews
 ```
 
+Diagnostic statuses are intentionally small:
+
+| Status | Meaning |
+| --- | --- |
+| `:complete` | The replay has complete effect result data. |
+| `:waiting` | Human review is pending, usually from an interrupted operation control. |
+| `:failed` | At least one effect result or timeline event failed. |
+| `:incomplete` | An effect intent exists without a recorded result. |
+
 Use `Jidoka.Debug.request/2` when you want a request-level view that combines
 prompt metadata, operation results, usage, timeline, journal, and replay
 diagnostics:
@@ -113,6 +122,17 @@ diagnostics:
 ```elixir
 {:ok, summary} = Jidoka.Debug.request(result)
 summary.prompt.messages
+summary.replay_diagnostics.status
+```
+
+For hibernated work, pass the snapshot directly. Add `session:` when you want
+the session id attached to the summary:
+
+```elixir
+{:hibernate, session, snapshot} = Jidoka.Session.run(session, "Refund A1001")
+
+{:ok, summary} = Jidoka.Debug.request(snapshot, session: session)
+summary.pending_reviews
 summary.replay_diagnostics.status
 ```
 

--- a/lib/jidoka/debug.ex
+++ b/lib/jidoka/debug.ex
@@ -222,6 +222,7 @@ defmodule Jidoka.Debug do
     diagnostics_from_parts(
       journal: replay.journal,
       events: replay.timeline,
+      pending_effects: replay_pending_effects(replay),
       pending_reviews: replay.pending_reviews,
       metadata: %{source: :replay, session_id: replay.session_id}
     )
@@ -445,6 +446,15 @@ defmodule Jidoka.Debug do
     |> map_get(:pending_review)
     |> List.wrap()
     |> Enum.reject(&is_nil/1)
+  end
+
+  defp replay_pending_effects(%Replay{snapshots: snapshots}) do
+    Enum.flat_map(snapshots, fn snapshot ->
+      snapshot
+      |> map_get(:pending_effects, [])
+      |> List.wrap()
+      |> Enum.reject(&is_nil/1)
+    end)
   end
 
   defp session_id(%Session{session_id: session_id}), do: session_id

--- a/lib/jidoka/debug.ex
+++ b/lib/jidoka/debug.ex
@@ -1,0 +1,407 @@
+defmodule Jidoka.Debug do
+  @moduledoc """
+  Data-first request debug and replay diagnostics.
+
+  `Jidoka.Debug` assembles useful debug views from values Jidoka already
+  produces: turn results, sessions, snapshots, journals, events, and replay
+  projections. It never calls LLMs, tools, memory stores, or runtime
+  capabilities.
+  """
+
+  alias Jidoka.Debug.{ReplayDiagnostics, RequestSummary}
+  alias Jidoka.Effect
+  alias Jidoka.Harness
+  alias Jidoka.Harness.{Replay, Session}
+  alias Jidoka.Runtime.AgentSnapshot
+  alias Jidoka.Turn
+
+  @doc """
+  Builds a request-level debug summary from a result, session, snapshot, or replay.
+
+  The summary combines prompt debug metadata, operation results, usage,
+  timeline, journal, pending reviews, and replay diagnostics. It is data-only
+  and never calls runtime capabilities.
+  """
+  @spec request(term(), keyword()) :: {:ok, RequestSummary.t()} | {:error, term()}
+  def request(target, opts \\ [])
+
+  def request({:ok, %Turn.Result{} = result}, opts), do: request(result, opts)
+
+  def request({:ok, %Session{} = session, %Turn.Result{} = result}, opts) do
+    request(result, Keyword.put(opts, :session, session))
+  end
+
+  def request({:hibernate, %AgentSnapshot{} = snapshot}, opts), do: request(snapshot, opts)
+
+  def request({:hibernate, %Session{} = session, %AgentSnapshot{} = snapshot}, opts) do
+    request(snapshot, Keyword.put(opts, :session, session))
+  end
+
+  def request({:error, reason}, _opts), do: {:error, reason}
+
+  def request(%Turn.Result{} = result, opts) do
+    debug = debug_metadata(result)
+    prompt = Map.get(debug, :prompt, %{}) || %{}
+    session = Keyword.get(opts, :session)
+    timeline = Jidoka.Trace.timeline(result.events, opts)
+
+    RequestSummary.new(
+      request_id: Map.get(debug, :request_id) || request_id_from_timeline(timeline),
+      agent_id: Map.get(debug, :agent_id) || agent_id_from_timeline(timeline),
+      session_id: session_id(session),
+      status: :finished,
+      model: Map.get(debug, :model) || Map.get(prompt, :model),
+      input: Map.get(debug, :input),
+      content: result.content,
+      value: result.value,
+      prompt: prompt,
+      context_keys: Map.get(debug, :context_keys, []),
+      operation_names: operation_names(prompt, result),
+      operation_results: Enum.map(result.agent_state.operation_results, &Jidoka.project/1),
+      memory: Map.get(prompt, :memory),
+      usage: result.usage,
+      timeline: timeline,
+      journal: Jidoka.project(result.journal),
+      pending_reviews: [],
+      diagnostics: Map.get(debug, :diagnostics, []),
+      replay_diagnostics: diagnose!(result),
+      metadata: Map.drop(debug, [:prompt, :diagnostics])
+    )
+  end
+
+  def request(%Session{} = session, opts) do
+    request_id = Keyword.get(opts, :request_id)
+
+    case session.result do
+      %Turn.Result{} = result when is_nil(request_id) ->
+        request(result, Keyword.put(opts, :session, session))
+
+      %Turn.Result{} = result ->
+        if request_id == result_request_id(result) do
+          request(result, Keyword.put(opts, :session, session))
+        else
+          request_from_snapshot(session, request_id, opts)
+        end
+
+      _other ->
+        request_from_snapshot(session, request_id, opts)
+    end
+  end
+
+  def request(%AgentSnapshot{} = snapshot, opts) do
+    session = Keyword.get(opts, :session)
+    state = snapshot.turn_state
+    prompt = prompt_debug_from_state(state)
+    timeline = Jidoka.Trace.timeline(state.events, opts)
+
+    RequestSummary.new(
+      request_id: state.request.request_id,
+      agent_id: snapshot.agent_id,
+      session_id: session_id(session),
+      status: state.status,
+      model: model_from_prompt(state.prompt),
+      input: state.request.input,
+      content: state.result,
+      value: state.result_value,
+      prompt: prompt,
+      context_keys: context_keys(state.request.context),
+      operation_names: operation_names(prompt, state),
+      operation_results: Enum.map(state.agent_state.operation_results, &Jidoka.project/1),
+      memory: memory_from_prompt(state.prompt),
+      usage: %{},
+      timeline: timeline,
+      journal: Jidoka.project(state.journal),
+      pending_reviews: pending_reviews(snapshot),
+      diagnostics: state.diagnostics,
+      replay_diagnostics: diagnose!(snapshot),
+      metadata: snapshot.metadata
+    )
+  end
+
+  def request(%Replay{} = replay, _opts) do
+    RequestSummary.new(
+      request_id: request_id_from_timeline(replay.timeline),
+      agent_id: replay.agent_id,
+      session_id: replay.session_id,
+      status: replay.status,
+      timeline: replay.timeline,
+      journal: replay.journal,
+      pending_reviews: replay.pending_reviews,
+      replay_diagnostics: diagnose!(replay),
+      content: replay_content(replay.result),
+      value: replay_value(replay.result),
+      metadata: replay.metadata
+    )
+  end
+
+  def request(other, _opts), do: {:error, {:unsupported_debug_request_target, other}}
+
+  @doc "Returns the latest request summary for a session."
+  @spec latest(Session.t(), keyword()) :: {:ok, RequestSummary.t()} | {:error, term()}
+  def latest(%Session{} = session, opts \\ []), do: request(session, opts)
+
+  @doc """
+  Diagnoses replayable runtime data without executing effects.
+
+  Diagnostics flag missing effect results, failed effect results, unsafe
+  effects, pending reviews, and failed timeline events.
+  """
+  @spec diagnose(term()) :: {:ok, ReplayDiagnostics.t()} | {:error, term()}
+  def diagnose(%Turn.Result{} = result) do
+    diagnostics_from_parts(
+      journal: result.journal,
+      events: result.events,
+      pending_reviews: [],
+      metadata: %{source: :turn_result}
+    )
+  end
+
+  def diagnose(%AgentSnapshot{} = snapshot) do
+    diagnostics_from_parts(
+      journal: snapshot.turn_state.journal,
+      events: snapshot.turn_state.events,
+      pending_effects: snapshot.turn_state.pending_effects,
+      pending_reviews: pending_reviews(snapshot),
+      metadata: %{source: :snapshot, snapshot_id: snapshot.snapshot_id}
+    )
+  end
+
+  def diagnose(%Session{} = session) do
+    with {:ok, replay} <- Harness.replay(session), do: diagnose(replay)
+  end
+
+  def diagnose(%Replay{} = replay) do
+    diagnostics_from_parts(
+      journal: replay.journal,
+      events: replay.timeline,
+      pending_reviews: replay.pending_reviews,
+      metadata: %{source: :replay, session_id: replay.session_id}
+    )
+  end
+
+  def diagnose(%Effect.Journal{} = journal) do
+    diagnostics_from_parts(journal: journal, events: [], pending_reviews: [], metadata: %{source: :journal})
+  end
+
+  def diagnose(other), do: {:error, {:unsupported_replay_diagnostics_target, other}}
+
+  defp diagnose!(target) do
+    case diagnose(target) do
+      {:ok, diagnostics} -> diagnostics
+      {:error, reason} -> ReplayDiagnostics.new!(status: :failed, warnings: [inspect(reason)])
+    end
+  end
+
+  defp diagnostics_from_parts(parts) do
+    {journal_intents, results} = journal_parts(Keyword.get(parts, :journal))
+    intents = merge_intents(journal_intents, Keyword.get(parts, :pending_effects, []))
+    events = Keyword.get(parts, :events, [])
+    pending_reviews = Keyword.get(parts, :pending_reviews, [])
+
+    result_ids = MapSet.new(Enum.map(results, &map_get(&1, :intent_id)))
+    missing = Enum.reject(intents, &(map_get(&1, :id) in result_ids))
+    failed_results = Enum.filter(results, &(map_get(&1, :status) == :error))
+    unsafe = Enum.filter(intents, &(map_get(&1, :idempotency) == :unsafe_once))
+    failed_events = Enum.filter(events, &failed_event?/1)
+
+    ReplayDiagnostics.new(
+      status: diagnostics_status(missing, failed_results, pending_reviews, failed_events),
+      intent_count: length(intents),
+      result_count: length(results),
+      event_count: length(events),
+      missing_effect_results: Enum.map(missing, &Jidoka.project/1),
+      failed_effect_results: Enum.map(failed_results, &Jidoka.project/1),
+      unsafe_effects: Enum.map(unsafe, &Jidoka.project/1),
+      pending_reviews: Enum.map(pending_reviews, &Jidoka.project/1),
+      failed_events: Enum.map(failed_events, &Jidoka.project/1),
+      warnings: warnings(missing, failed_results, unsafe, pending_reviews, failed_events),
+      metadata: Keyword.get(parts, :metadata, %{})
+    )
+  end
+
+  defp diagnostics_status(_missing, _failed, [_review | _rest], _failed_events), do: :waiting
+  defp diagnostics_status(_missing, [_failed | _rest], _pending, _failed_events), do: :failed
+  defp diagnostics_status(_missing, _failed, _pending, [_event | _rest]), do: :failed
+  defp diagnostics_status([_missing | _rest], _failed, _pending, _failed_events), do: :incomplete
+  defp diagnostics_status(_missing, _failed, _pending, _failed_events), do: :complete
+
+  defp warnings(missing, failed_results, unsafe, pending_reviews, failed_events) do
+    []
+    |> maybe_warn(missing != [], "Some effect intents do not have recorded results.")
+    |> maybe_warn(failed_results != [], "Some effect results failed.")
+    |> maybe_warn(unsafe != [], "Some unsafe_once effects are not replay-safe.")
+    |> maybe_warn(pending_reviews != [], "Human review is still pending.")
+    |> maybe_warn(failed_events != [], "Timeline contains failed events.")
+  end
+
+  defp maybe_warn(warnings, true, message), do: warnings ++ [message]
+  defp maybe_warn(warnings, false, _message), do: warnings
+
+  defp journal_parts(%Effect.Journal{} = journal), do: {Map.values(journal.intents), Map.values(journal.results)}
+
+  defp journal_parts(%{intents: intents, results: results}) when is_list(intents) and is_list(results) do
+    {intents, results}
+  end
+
+  defp journal_parts(%{"intents" => intents, "results" => results}) when is_list(intents) and is_list(results) do
+    {intents, results}
+  end
+
+  defp journal_parts(_journal), do: {[], []}
+
+  defp merge_intents(intents, pending_effects) when is_list(intents) and is_list(pending_effects) do
+    by_id = Map.new(intents, &{map_get(&1, :id), &1})
+
+    pending_effects
+    |> Enum.reduce(by_id, fn effect, acc -> Map.put_new(acc, map_get(effect, :id), effect) end)
+    |> Map.values()
+  end
+
+  defp request_from_snapshot(%Session{} = session, nil, opts) do
+    case Session.latest_snapshot(session) do
+      %AgentSnapshot{} = snapshot -> request(snapshot, Keyword.put(opts, :session, session))
+      nil -> request_from_session_data(session, opts)
+    end
+  end
+
+  defp request_from_snapshot(%Session{} = session, request_id, opts) do
+    snapshot =
+      Enum.find(session.snapshots, fn %AgentSnapshot{} = snapshot ->
+        snapshot.turn_state.request.request_id == request_id
+      end)
+
+    case snapshot do
+      %AgentSnapshot{} = snapshot -> request(snapshot, Keyword.put(opts, :session, session))
+      nil -> request_from_session_data(session, opts)
+    end
+  end
+
+  defp request_from_session_data(%Session{} = session, _opts) do
+    RequestSummary.new(
+      request_id: session.requests |> List.last() |> then(&request_id/1),
+      agent_id: session.agent_id,
+      session_id: session.session_id,
+      status: session.status,
+      pending_reviews: Enum.map(session.pending_reviews, &Jidoka.project/1),
+      error: session.error,
+      replay_diagnostics: diagnose!(session),
+      metadata: session.metadata
+    )
+  end
+
+  defp debug_metadata(%Turn.Result{metadata: metadata}) do
+    case map_get(metadata, :debug) do
+      %{} = debug -> atomize_known_debug(debug)
+      _other -> %{}
+    end
+  end
+
+  defp atomize_known_debug(%{} = debug) do
+    %{
+      request_id: map_get(debug, :request_id),
+      agent_id: map_get(debug, :agent_id),
+      model: map_get(debug, :model),
+      input: map_get(debug, :input),
+      context_keys: map_get(debug, :context_keys, []),
+      prompt: map_get(debug, :prompt, %{}),
+      diagnostics: map_get(debug, :diagnostics, []),
+      started_at_ms: map_get(debug, :started_at_ms)
+    }
+  end
+
+  defp prompt_debug_from_state(%Turn.State{prompt: nil}), do: %{}
+
+  defp prompt_debug_from_state(%Turn.State{prompt: %{} = prompt}) do
+    %{
+      model: map_get(prompt, :model),
+      loop_index: map_get(prompt, :loop_index),
+      messages: map_get(prompt, :messages, []),
+      message_count: length(map_get(prompt, :messages, [])),
+      operations: map_get(prompt, :operations, []),
+      operation_names: Enum.map(map_get(prompt, :operations, []), &map_get(&1, :name)),
+      operation_count: length(map_get(prompt, :operations, [])),
+      result: map_get(prompt, :result),
+      memory: map_get(prompt, :memory),
+      generation: map_get(prompt, :generation)
+    }
+  end
+
+  defp model_from_prompt(%{} = prompt), do: map_get(prompt, :model)
+  defp model_from_prompt(_prompt), do: nil
+
+  defp memory_from_prompt(%{} = prompt), do: map_get(prompt, :memory)
+  defp memory_from_prompt(_prompt), do: nil
+
+  defp operation_names(%{} = prompt, %Turn.Result{} = result) do
+    prompt_names = prompt |> map_get(:operation_names, []) |> Enum.reject(&is_nil/1)
+
+    result_names =
+      result.agent_state.operation_results
+      |> Enum.map(& &1.operation)
+      |> Enum.reject(&is_nil/1)
+
+    Enum.uniq(prompt_names ++ result_names)
+  end
+
+  defp operation_names(%{} = prompt, %Turn.State{} = state) do
+    prompt_names = prompt |> map_get(:operation_names, []) |> Enum.reject(&is_nil/1)
+
+    result_names =
+      state.agent_state.operation_results
+      |> Enum.map(& &1.operation)
+      |> Enum.reject(&is_nil/1)
+
+    Enum.uniq(prompt_names ++ result_names)
+  end
+
+  defp operation_names(_prompt, _result), do: []
+
+  defp result_request_id(%Turn.Result{} = result) do
+    result
+    |> debug_metadata()
+    |> Map.get(:request_id)
+  end
+
+  defp request_id(%Turn.Request{request_id: request_id}), do: request_id
+  defp request_id(_request), do: nil
+
+  defp request_id_from_timeline(timeline), do: Enum.find_value(timeline, &map_get(&1, :request_id))
+  defp agent_id_from_timeline(timeline), do: Enum.find_value(timeline, &map_get(&1, :agent_id))
+
+  defp pending_reviews(%AgentSnapshot{metadata: metadata}) do
+    metadata
+    |> map_get(:pending_review)
+    |> List.wrap()
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp session_id(%Session{session_id: session_id}), do: session_id
+  defp session_id(_session), do: nil
+
+  defp context_keys(%{} = context) do
+    context
+    |> Map.keys()
+    |> Enum.map(&to_string/1)
+    |> Enum.sort()
+  end
+
+  defp context_keys(_context), do: []
+
+  defp failed_event?(%{} = event), do: map_get(event, :status) == :failed or map_get(event, :event) == :turn_failed
+  defp failed_event?(_event), do: false
+
+  defp replay_content(%{content: content}) when is_binary(content), do: content
+  defp replay_content(%{"content" => content}) when is_binary(content), do: content
+  defp replay_content(_result), do: nil
+
+  defp replay_value(%{} = result), do: map_get(result, :value)
+  defp replay_value(_result), do: nil
+
+  defp map_get(map, key, default \\ nil)
+
+  defp map_get(%{} = map, key, default) when is_atom(key) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+  end
+
+  defp map_get(_map, _key, default), do: default
+end

--- a/lib/jidoka/debug.ex
+++ b/lib/jidoka/debug.ex
@@ -111,7 +111,7 @@ defmodule Jidoka.Debug do
       usage: %{},
       timeline: timeline,
       journal: Jidoka.project(state.journal),
-      pending_reviews: pending_reviews(snapshot),
+      pending_reviews: Enum.map(pending_reviews(snapshot), &Jidoka.project/1),
       diagnostics: state.diagnostics,
       replay_diagnostics: diagnose!(snapshot),
       metadata: snapshot.metadata
@@ -260,7 +260,7 @@ defmodule Jidoka.Debug do
   defp request_from_snapshot(%Session{} = session, nil, opts) do
     case Session.latest_snapshot(session) do
       %AgentSnapshot{} = snapshot -> request(snapshot, Keyword.put(opts, :session, session))
-      nil -> request_from_session_data(session, opts)
+      nil -> request_from_session_data(session, nil, opts)
     end
   end
 
@@ -272,21 +272,39 @@ defmodule Jidoka.Debug do
 
     case snapshot do
       %AgentSnapshot{} = snapshot -> request(snapshot, Keyword.put(opts, :session, session))
-      nil -> request_from_session_data(session, opts)
+      nil -> request_from_session_data(session, request_id, opts)
     end
   end
 
-  defp request_from_session_data(%Session{} = session, _opts) do
+  defp request_from_session_data(%Session{} = session, request_id, _opts) do
+    request = session_request(session, request_id)
+
+    if is_nil(request) and is_binary(request_id) do
+      {:error, {:request_debug_not_found, session.session_id, request_id}}
+    else
+      request_summary_from_session_data(session, request)
+    end
+  end
+
+  defp request_summary_from_session_data(%Session{} = session, request) do
     RequestSummary.new(
-      request_id: session.requests |> List.last() |> then(&request_id/1),
+      request_id: request_id(request),
       agent_id: session.agent_id,
       session_id: session.session_id,
       status: session.status,
+      input: request_input(request),
+      context_keys: request_context_keys(request),
       pending_reviews: Enum.map(session.pending_reviews, &Jidoka.project/1),
       error: session.error,
       replay_diagnostics: diagnose!(session),
       metadata: session.metadata
     )
+  end
+
+  defp session_request(%Session{requests: requests}, nil), do: List.last(requests)
+
+  defp session_request(%Session{requests: requests}, request_id) when is_binary(request_id) do
+    Enum.find(requests, &(request_id(&1) == request_id))
   end
 
   defp debug_metadata(%Turn.Result{metadata: metadata}) do
@@ -364,6 +382,12 @@ defmodule Jidoka.Debug do
 
   defp request_id(%Turn.Request{request_id: request_id}), do: request_id
   defp request_id(_request), do: nil
+
+  defp request_input(%Turn.Request{input: input}), do: input
+  defp request_input(_request), do: nil
+
+  defp request_context_keys(%Turn.Request{context: context}), do: context_keys(context)
+  defp request_context_keys(_request), do: []
 
   defp request_id_from_timeline(timeline), do: Enum.find_value(timeline, &map_get(&1, :request_id))
   defp agent_id_from_timeline(timeline), do: Enum.find_value(timeline, &map_get(&1, :agent_id))

--- a/lib/jidoka/debug.ex
+++ b/lib/jidoka/debug.ex
@@ -6,6 +6,38 @@ defmodule Jidoka.Debug do
   produces: turn results, sessions, snapshots, journals, events, and replay
   projections. It never calls LLMs, tools, memory stores, or runtime
   capabilities.
+
+  Use this module after a turn when you need one value that explains the
+  request: prompt messages, selected operations, operation results, usage,
+  timeline, journal, pending reviews, and replay diagnostics.
+
+      {:ok, result} = Jidoka.turn(MyApp.Agent, "Check order A1001")
+      {:ok, summary} = Jidoka.Debug.request(result)
+
+      summary.prompt.messages
+      summary.operation_results
+      summary.usage
+      summary.replay_diagnostics.status
+
+  Request summaries accept:
+
+  - `Jidoka.Turn.Result` for a completed turn;
+  - `Jidoka.Harness.Session` for the latest request, or a specific
+    `request_id:`;
+  - `Jidoka.Runtime.AgentSnapshot` for hibernated work;
+  - `Jidoka.Harness.Replay` for stored replay projections;
+  - common return tuples such as `{:ok, result}` and `{:hibernate, snapshot}`.
+
+  `Jidoka.Debug` intentionally stores context keys, not full context values.
+  Keep secrets and large application payloads in your application data, not in
+  debug summaries.
+
+  Replay diagnostics use four statuses:
+
+  - `:complete` - all recorded effect intents have results;
+  - `:waiting` - human review is pending;
+  - `:failed` - an effect result or timeline event failed;
+  - `:incomplete` - at least one effect intent has no recorded result.
   """
 
   alias Jidoka.Debug.{ReplayDiagnostics, RequestSummary}
@@ -21,6 +53,13 @@ defmodule Jidoka.Debug do
   The summary combines prompt debug metadata, operation results, usage,
   timeline, journal, pending reviews, and replay diagnostics. It is data-only
   and never calls runtime capabilities.
+
+  Options:
+
+  - `:session` - attach a session id when summarizing a snapshot or result;
+  - `:request_id` - when the target is a session, select a specific stored
+    request or snapshot. Unknown ids return
+    `{:error, {:request_debug_not_found, session_id, request_id}}`.
   """
   @spec request(term(), keyword()) :: {:ok, RequestSummary.t()} | {:error, term()}
   def request(target, opts \\ [])
@@ -136,7 +175,12 @@ defmodule Jidoka.Debug do
 
   def request(other, _opts), do: {:error, {:unsupported_debug_request_target, other}}
 
-  @doc "Returns the latest request summary for a session."
+  @doc """
+  Returns the latest request summary for a session.
+
+  This is a convenience wrapper around `request/2`. Pass `request_id:` to
+  select a specific request in the session history.
+  """
   @spec latest(Session.t(), keyword()) :: {:ok, RequestSummary.t()} | {:error, term()}
   def latest(%Session{} = session, opts \\ []), do: request(session, opts)
 
@@ -145,6 +189,10 @@ defmodule Jidoka.Debug do
 
   Diagnostics flag missing effect results, failed effect results, unsafe
   effects, pending reviews, and failed timeline events.
+
+  Use this when you have a session, snapshot, replay, result, or journal and
+  need to know whether the recorded data is complete enough to inspect or
+  replay safely.
   """
   @spec diagnose(term()) :: {:ok, ReplayDiagnostics.t()} | {:error, term()}
   def diagnose(%Turn.Result{} = result) do

--- a/lib/jidoka/debug/replay_diagnostics.ex
+++ b/lib/jidoka/debug/replay_diagnostics.ex
@@ -1,0 +1,51 @@
+defmodule Jidoka.Debug.ReplayDiagnostics do
+  @moduledoc """
+  Diagnostic view for replayable Jidoka runtime data.
+
+  Replay diagnostics explain whether recorded effects are complete and safe to
+  reason about without executing providers or tools.
+  """
+
+  alias Jidoka.Schema
+
+  @statuses [:complete, :waiting, :failed, :incomplete]
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              status: Schema.atom_enum(@statuses),
+              intent_count: Zoi.integer() |> Zoi.gte(0) |> Zoi.default(0),
+              result_count: Zoi.integer() |> Zoi.gte(0) |> Zoi.default(0),
+              event_count: Zoi.integer() |> Zoi.gte(0) |> Zoi.default(0),
+              missing_effect_results: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              failed_effect_results: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              unsafe_effects: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              pending_reviews: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              failed_events: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              warnings: Zoi.array(Zoi.string()) |> Zoi.default([]),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type status :: :complete | :waiting | :failed | :incomplete
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for replay diagnostics."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Returns the supported replay diagnostic statuses."
+  @spec statuses() :: [status()]
+  def statuses, do: @statuses
+
+  @doc "Builds replay diagnostics from normalized attributes."
+  @spec new(keyword() | map()) :: {:ok, t()} | {:error, term()}
+  def new(attrs), do: Schema.parse(@schema, attrs)
+
+  @doc "Builds replay diagnostics or raises when the attributes are invalid."
+  @spec new!(keyword() | map()) :: t()
+  def new!(attrs), do: Schema.parse!(@schema, attrs, "debug replay diagnostics")
+end

--- a/lib/jidoka/debug/request_summary.ex
+++ b/lib/jidoka/debug/request_summary.ex
@@ -1,0 +1,54 @@
+defmodule Jidoka.Debug.RequestSummary do
+  @moduledoc """
+  Request-level debug summary assembled from Jidoka runtime data.
+
+  This is a data-only view. It does not call providers, tools, or runtime
+  capabilities.
+  """
+
+  alias Jidoka.Schema
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              request_id: Schema.non_empty_string() |> Zoi.nullish(),
+              agent_id: Schema.non_empty_string() |> Zoi.nullish(),
+              session_id: Schema.non_empty_string() |> Zoi.nullish(),
+              status: Zoi.atom() |> Zoi.nullish(),
+              model: Zoi.string() |> Zoi.nullish(),
+              input: Zoi.string() |> Zoi.nullish(),
+              content: Zoi.string() |> Zoi.nullish(),
+              value: Zoi.any() |> Zoi.nullish(),
+              prompt: Zoi.map() |> Zoi.default(%{}),
+              context_keys: Zoi.array(Zoi.string()) |> Zoi.default([]),
+              operation_names: Zoi.array(Zoi.string()) |> Zoi.default([]),
+              operation_results: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              memory: Zoi.map() |> Zoi.nullish(),
+              usage: Zoi.map() |> Zoi.default(%{}),
+              timeline: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              journal: Zoi.map() |> Zoi.default(%{intents: [], results: []}),
+              pending_reviews: Zoi.array(Zoi.map()) |> Zoi.default([]),
+              diagnostics: Zoi.array(Zoi.any()) |> Zoi.default([]),
+              replay_diagnostics: Zoi.lazy({Jidoka.Debug.ReplayDiagnostics, :schema, []}) |> Zoi.nullish(),
+              error: Zoi.any() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for request debug summaries."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Builds a request debug summary from normalized attributes."
+  @spec new(keyword() | map()) :: {:ok, t()} | {:error, term()}
+  def new(attrs), do: Schema.parse(@schema, attrs)
+
+  @doc "Builds a request debug summary or raises when the attributes are invalid."
+  @spec new!(keyword() | map()) :: t()
+  def new!(attrs), do: Schema.parse!(@schema, attrs, "debug request summary")
+end

--- a/lib/jidoka/harness/replay.ex
+++ b/lib/jidoka/harness/replay.ex
@@ -68,6 +68,10 @@ defmodule Jidoka.Harness.Replay do
     )
   end
 
+  @doc "Returns data-only diagnostics for a replay, session, snapshot, result, or journal."
+  @spec diagnose(term()) :: {:ok, Jidoka.Debug.ReplayDiagnostics.t()} | {:error, term()}
+  def diagnose(target), do: Jidoka.Debug.diagnose(target)
+
   defp snapshot_summary(%AgentSnapshot{} = snapshot) do
     %{
       snapshot_id: snapshot.snapshot_id,

--- a/lib/jidoka/inspection.ex
+++ b/lib/jidoka/inspection.ex
@@ -7,6 +7,7 @@ defmodule Jidoka.Inspection do
   """
 
   alias Jidoka.Agent
+  alias Jidoka.Debug
   alias Jidoka.Effect
   alias Jidoka.Error
   alias Jidoka.Inspection.Preflight
@@ -30,6 +31,8 @@ defmodule Jidoka.Inspection do
           | AgentSnapshot.t()
           | Harness.Session.t()
           | Harness.Replay.t()
+          | Debug.RequestSummary.t()
+          | Debug.ReplayDiagnostics.t()
           | Effect.Journal.t()
           | Effect.Intent.t()
           | Effect.Result.t()
@@ -70,6 +73,8 @@ defmodule Jidoka.Inspection do
   def inspect(%AgentSnapshot{} = snapshot, _opts), do: snapshot_view(snapshot)
   def inspect(%Harness.Session{} = session, _opts), do: session_view(session)
   def inspect(%Harness.Replay{} = replay, _opts), do: replay_view(replay)
+  def inspect(%Debug.RequestSummary{} = summary, _opts), do: request_summary_view(summary)
+  def inspect(%Debug.ReplayDiagnostics{} = diagnostics, _opts), do: replay_diagnostics_view(diagnostics)
   def inspect(%Effect.Journal{} = journal, _opts), do: journal_view(journal)
   def inspect(%Effect.Intent{} = intent, _opts), do: intent_view(intent)
   def inspect(%Effect.Result{} = result, _opts), do: effect_result_view(result)
@@ -189,6 +194,12 @@ defmodule Jidoka.Inspection do
   end
 
   defp replay_view(%Harness.Replay{} = replay) do
+    diagnostics =
+      case Harness.Replay.diagnose(replay) do
+        {:ok, diagnostics} -> Jidoka.project(diagnostics)
+        {:error, reason} -> %{error: Jidoka.error_to_map(reason)}
+      end
+
     %{
       kind: :replay,
       session_id: replay.session_id,
@@ -198,9 +209,22 @@ defmodule Jidoka.Inspection do
       timeline: replay.timeline,
       journal: replay.journal,
       pending_reviews: replay.pending_reviews,
+      diagnostics: diagnostics,
       result: replay.result,
       metadata: replay.metadata
     }
+  end
+
+  defp request_summary_view(%Debug.RequestSummary{} = summary) do
+    summary
+    |> Jidoka.project()
+    |> Map.put(:kind, :request_debug)
+  end
+
+  defp replay_diagnostics_view(%Debug.ReplayDiagnostics{} = diagnostics) do
+    diagnostics
+    |> Jidoka.project()
+    |> Map.put(:kind, :replay_diagnostics)
   end
 
   defp journal_view(%Effect.Journal{} = journal) do

--- a/lib/jidoka/kino.ex
+++ b/lib/jidoka/kino.ex
@@ -77,6 +77,12 @@ defmodule Jidoka.Kino do
   def debug_agent(target, opts \\ []), do: AgentView.debug_agent(target, opts)
 
   @doc """
+  Renders a request-level debug summary from a turn result, session, snapshot, or replay.
+  """
+  @spec debug_request(term(), keyword()) :: {:ok, Jidoka.Debug.RequestSummary.t()} | {:error, String.t()}
+  def debug_request(target, opts \\ []), do: AgentView.debug_request(target, opts)
+
+  @doc """
   Runs `Jidoka.preflight/3` and renders prompt/timeline tables.
   """
   @spec preflight(Jidoka.plan_input() | module(), Jidoka.request_input(), keyword()) ::

--- a/lib/jidoka/kino/agent_view.ex
+++ b/lib/jidoka/kino/agent_view.ex
@@ -135,7 +135,7 @@ defmodule Jidoka.Kino.AgentView do
       |> Map.get(:operation_results, [])
       |> operation_result_rows()
 
-    render_optional_table("Operation results", operation_rows, [:operation, :status, :preview])
+    render_optional_table("Operation results", operation_rows, [:operation, :preview])
 
     diagnostic_rows =
       projected
@@ -171,7 +171,6 @@ defmodule Jidoka.Kino.AgentView do
     Enum.map(results, fn result ->
       %{
         operation: Map.get(result, :operation),
-        status: Map.get(result, :status),
         preview: result |> Map.get(:output) |> Render.preview(220)
       }
     end)

--- a/lib/jidoka/kino/agent_view.ex
+++ b/lib/jidoka/kino/agent_view.ex
@@ -19,6 +19,21 @@ defmodule Jidoka.Kino.AgentView do
   end
 
   @doc false
+  @spec debug_request(term(), keyword()) :: {:ok, Jidoka.Debug.RequestSummary.t()} | {:error, String.t()}
+  def debug_request(target, opts \\ []) do
+    case Jidoka.Debug.request(target, opts) do
+      {:ok, summary} ->
+        render_request_summary(summary)
+        {:ok, summary}
+
+      {:error, reason} ->
+        message = Jidoka.Error.format(reason)
+        Render.markdown("### Request Debug\n\n#{Render.escape_markdown(message)}")
+        {:error, message}
+    end
+  end
+
+  @doc false
   @spec preflight(Jidoka.plan_input() | module(), Jidoka.request_input(), keyword()) ::
           {:ok, Preflight.t()} | {:error, String.t()}
   def preflight(agent_or_plan, request_input, opts \\ []) do
@@ -101,6 +116,82 @@ defmodule Jidoka.Kino.AgentView do
     Render.table("Preflight summary", preflight_rows(preflight), keys: [:property, :value])
     render_optional_table("Prompt messages", prompt_message_rows(preflight.prompt.messages), [:role, :content])
     render_optional_table("Preflight timeline", preflight.timeline, timeline_keys(preflight.timeline))
+  end
+
+  defp render_request_summary(summary) do
+    projected = Jidoka.project(summary)
+
+    Render.table("Request summary", request_summary_rows(projected), keys: [:property, :value])
+
+    prompt_messages =
+      projected
+      |> get_in([:prompt, :messages])
+      |> List.wrap()
+
+    render_optional_table("Prompt messages", prompt_messages, [:role, :content])
+
+    operation_rows =
+      projected
+      |> Map.get(:operation_results, [])
+      |> operation_result_rows()
+
+    render_optional_table("Operation results", operation_rows, [:operation, :status, :preview])
+
+    diagnostic_rows =
+      projected
+      |> Map.get(:replay_diagnostics)
+      |> replay_diagnostic_rows()
+
+    render_optional_table("Replay diagnostics", diagnostic_rows, [:property, :value])
+
+    render_optional_table(
+      "Request timeline",
+      Map.get(projected, :timeline, []),
+      timeline_keys(Map.get(projected, :timeline, []))
+    )
+  end
+
+  defp request_summary_rows(summary) do
+    [
+      %{property: "request id", value: Map.get(summary, :request_id)},
+      %{property: "session id", value: Map.get(summary, :session_id)},
+      %{property: "agent id", value: Map.get(summary, :agent_id)},
+      %{property: "status", value: Map.get(summary, :status)},
+      %{property: "model", value: Map.get(summary, :model)},
+      %{property: "input", value: summary |> Map.get(:input) |> Render.preview(200)},
+      %{property: "content", value: summary |> Map.get(:content) |> Render.preview(220)},
+      %{property: "operations", value: summary |> Map.get(:operation_names, []) |> Render.format_list()},
+      %{property: "usage", value: summary |> Map.get(:usage, %{}) |> Render.inspect_value(12)},
+      %{property: "diagnostics", value: summary |> Map.get(:diagnostics, []) |> Render.inspect_value(8)}
+    ]
+    |> Render.reject_blank_rows()
+  end
+
+  defp operation_result_rows(results) when is_list(results) do
+    Enum.map(results, fn result ->
+      %{
+        operation: Map.get(result, :operation),
+        status: Map.get(result, :status),
+        preview: result |> Map.get(:output) |> Render.preview(220)
+      }
+    end)
+  end
+
+  defp replay_diagnostic_rows(nil), do: []
+
+  defp replay_diagnostic_rows(diagnostics) do
+    [
+      %{property: "status", value: Map.get(diagnostics, :status)},
+      %{property: "intents", value: Map.get(diagnostics, :intent_count)},
+      %{property: "results", value: Map.get(diagnostics, :result_count)},
+      %{property: "events", value: Map.get(diagnostics, :event_count)},
+      %{property: "missing effect results", value: length(Map.get(diagnostics, :missing_effect_results, []))},
+      %{property: "failed effect results", value: length(Map.get(diagnostics, :failed_effect_results, []))},
+      %{property: "unsafe effects", value: length(Map.get(diagnostics, :unsafe_effects, []))},
+      %{property: "pending reviews", value: length(Map.get(diagnostics, :pending_reviews, []))},
+      %{property: "warnings", value: diagnostics |> Map.get(:warnings, []) |> Render.format_list()}
+    ]
+    |> Render.reject_blank_rows()
   end
 
   defp agent_summary_rows(inspection, spec, plan) do

--- a/lib/jidoka/projection.ex
+++ b/lib/jidoka/projection.ex
@@ -375,6 +375,18 @@ defmodule Jidoka.Projection do
     |> project_value()
   end
 
+  def project(%Jidoka.Debug.RequestSummary{} = summary) do
+    summary
+    |> Map.from_struct()
+    |> project_value()
+  end
+
+  def project(%Jidoka.Debug.ReplayDiagnostics{} = diagnostics) do
+    diagnostics
+    |> Map.from_struct()
+    |> project_value()
+  end
+
   def project(%Jidoka.Trace.Policy{} = policy) do
     %{
       enabled: policy.enabled,

--- a/lib/jidoka/turn/result.ex
+++ b/lib/jidoka/turn/result.ex
@@ -3,6 +3,7 @@ defmodule Jidoka.Turn.Result do
 
   alias Jidoka.Schema
   alias Jidoka.Agent
+  alias Jidoka.Config
   alias Jidoka.Effect
   alias Jidoka.Turn
 
@@ -41,7 +42,52 @@ defmodule Jidoka.Turn.Result do
       agent_state: state.agent_state,
       journal: state.journal,
       events: state.events,
-      usage: Jidoka.Usage.from_journal(state.journal)
+      usage: Jidoka.Usage.from_journal(state.journal),
+      metadata: %{debug: debug_metadata(state)}
     )
   end
+
+  defp debug_metadata(%Turn.State{} = state) do
+    %{
+      request_id: state.request.request_id,
+      agent_id: state.spec.id,
+      model: Config.model_ref(state.spec.model),
+      input: state.request.input,
+      context_keys: context_keys(state.request.context),
+      prompt: prompt_debug(state.prompt),
+      diagnostics: state.diagnostics,
+      started_at_ms: state.started_at_ms
+    }
+  end
+
+  defp prompt_debug(nil), do: nil
+
+  defp prompt_debug(%{} = prompt) do
+    operations = Map.get(prompt, :operations, Map.get(prompt, "operations", []))
+
+    %{
+      model: Map.get(prompt, :model, Map.get(prompt, "model")),
+      loop_index: Map.get(prompt, :loop_index, Map.get(prompt, "loop_index")),
+      messages: Map.get(prompt, :messages, Map.get(prompt, "messages", [])),
+      message_count: length(Map.get(prompt, :messages, Map.get(prompt, "messages", []))),
+      operations: operations,
+      operation_names: Enum.map(operations, &operation_name/1),
+      operation_count: length(operations),
+      result: Map.get(prompt, :result, Map.get(prompt, "result")),
+      memory: Map.get(prompt, :memory, Map.get(prompt, "memory")),
+      generation: Map.get(prompt, :generation, Map.get(prompt, "generation"))
+    }
+  end
+
+  defp operation_name(%{} = operation), do: Map.get(operation, :name, Map.get(operation, "name"))
+  defp operation_name(_operation), do: nil
+
+  defp context_keys(%{} = context) do
+    context
+    |> Map.keys()
+    |> Enum.map(&to_string/1)
+    |> Enum.sort()
+  end
+
+  defp context_keys(_context), do: []
 end

--- a/mix.exs
+++ b/mix.exs
@@ -243,6 +243,8 @@ defmodule Jidoka.MixProject do
         Jidoka.Import,
         Jidoka.Import.AgentDocument,
         Jidoka.Export,
+        Jidoka.Debug,
+        ~r/^Jidoka\.Debug\./,
         Jidoka.Inspection,
         Jidoka.Inspection.Preflight,
         Jidoka.Projection
@@ -285,6 +287,7 @@ defmodule Jidoka.MixProject do
       Jidoka.Handoff,
       Jidoka.Harness,
       Jidoka.Import,
+      Jidoka.Debug,
       Jidoka.Inspection,
       Jidoka.Kino,
       Jidoka.Memory,

--- a/test/integration/debug_replay_integration_test.exs
+++ b/test/integration/debug_replay_integration_test.exs
@@ -1,0 +1,281 @@
+defmodule Jidoka.DebugReplayIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.Agent
+  alias Jidoka.Agent.Spec.{Controls, Operation}
+  alias Jidoka.Debug
+  alias Jidoka.Debug.{ReplayDiagnostics, RequestSummary}
+  alias Jidoka.Effect
+  alias Jidoka.Harness
+  alias Jidoka.Harness.Session
+  alias Jidoka.Review
+  alias Jidoka.Runtime.{AgentSnapshot, LocalOperations}
+  alias Jidoka.Turn
+
+  import Jidoka.TestSupport, only: [count_results: 2]
+
+  defmodule RequireRefundReviewControl do
+    @moduledoc false
+
+    use Jidoka.Control, name: "require_refund_review"
+
+    @impl true
+    def call(_operation), do: {:interrupt, :approval_required}
+  end
+
+  test "completed session debug summary includes prompt, operations, usage, and replay diagnostics" do
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(Jidoka.IntegrationSupport.AccountAgent.spec(),
+               session_id: "sess_debug_completed"
+             )
+
+    request =
+      Turn.Request.new!(
+        input: "Check account acct_100.",
+        request_id: "turn_debug_completed",
+        context: %{test_pid: self()}
+      )
+
+    assert {:ok, %Session{} = session, %Turn.Result{} = result} =
+             Harness.run_session(session, request,
+               llm: account_llm("acct_100"),
+               operations: account_operations()
+             )
+
+    assert_receive {:account_lookup_called, "acct_100"}
+
+    assert {:ok,
+            %RequestSummary{
+              request_id: "turn_debug_completed",
+              session_id: "sess_debug_completed",
+              agent_id: "multi_turn_account_agent",
+              status: :finished,
+              model: "test:model",
+              input: "Check account acct_100.",
+              content: "Account acct_100 is on the Pro plan.",
+              context_keys: ["test_pid"],
+              operation_names: ["account_lookup"],
+              replay_diagnostics: %ReplayDiagnostics{status: :complete}
+            } = summary} = Debug.latest(session)
+
+    assert result.metadata.debug.request_id == summary.request_id
+    assert Enum.map(summary.prompt.messages, & &1.role) == [:system, :user, :tool]
+    assert [%{operation: "account_lookup", output: %{account_id: "acct_100"}}] = summary.operation_results
+    assert summary.usage.llm_calls == 2
+    assert summary.usage.total_tokens == 12
+
+    assert %{kind: :request_debug, replay_diagnostics: %{status: :complete}} =
+             Jidoka.inspect(summary)
+  end
+
+  test "missing session request ids fail instead of returning the latest request" do
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(Jidoka.IntegrationSupport.AccountAgent.spec(),
+               session_id: "sess_debug_missing_request"
+             )
+
+    assert {:ok, %Session{} = session, %Turn.Result{}} =
+             Harness.run_session(
+               session,
+               Turn.Request.new!(input: "Check account acct_200.", request_id: "turn_present"),
+               llm: account_llm("acct_200"),
+               operations: account_operations()
+             )
+
+    assert {:ok, %RequestSummary{request_id: "turn_present"}} =
+             Debug.request(session, request_id: "turn_present")
+
+    assert {:error, {:request_debug_not_found, "sess_debug_missing_request", "turn_missing"}} =
+             Debug.request(session, request_id: "turn_missing")
+  end
+
+  test "checkpointed session debug summary captures incomplete pending effects" do
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(Jidoka.IntegrationSupport.AccountAgent.spec(),
+               session_id: "sess_debug_checkpoint"
+             )
+
+    assert {:hibernate, %Session{} = session, %AgentSnapshot{} = snapshot} =
+             Harness.run_session(session, "Check account acct_300.",
+               llm: account_llm("acct_300"),
+               operations: account_operations(),
+               checkpoint: :after_prompt
+             )
+
+    assert snapshot.cursor.phase == :after_prompt
+
+    assert {:ok,
+            %RequestSummary{
+              status: :running,
+              replay_diagnostics: %ReplayDiagnostics{
+                status: :incomplete,
+                missing_effect_results: [_missing],
+                warnings: warnings
+              }
+            }} = Debug.latest(session)
+
+    assert "Some effect intents do not have recorded results." in warnings
+  end
+
+  test "pending human review debug summary is durable and marks replay waiting" do
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(refund_spec(), session_id: "sess_debug_review")
+
+    assert {:hibernate, %Session{status: :waiting} = session, %AgentSnapshot{} = snapshot} =
+             Harness.run_session(session, "Refund order_123",
+               llm: refund_llm("order_123"),
+               operations: refund_operations(self())
+             )
+
+    refute_received {:refund_called, _arguments, _idempotency}
+
+    assert {:ok,
+            %RequestSummary{
+              status: :waiting,
+              pending_reviews: [%{operation: "refund_order", arguments: %{"order_id" => "order_123"}}],
+              replay_diagnostics: %ReplayDiagnostics{
+                status: :waiting,
+                missing_effect_results: [_missing],
+                pending_reviews: [%{operation: "refund_order"}],
+                unsafe_effects: [_unsafe],
+                warnings: warnings
+              }
+            }} = Debug.latest(session)
+
+    assert "Human review is still pending." in warnings
+    assert "Some unsafe_once effects are not replay-safe." in warnings
+
+    assert {:ok, serialized} = AgentSnapshot.serialize(snapshot)
+    assert {:ok, %AgentSnapshot{} = deserialized} = AgentSnapshot.deserialize(serialized)
+
+    assert {:ok,
+            %RequestSummary{
+              session_id: "sess_debug_review",
+              replay_diagnostics: %ReplayDiagnostics{status: :waiting}
+            }} = Debug.request(deserialized, session: session)
+  end
+
+  test "approved unsafe operations finish but still surface replay safety warnings" do
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(refund_spec(), session_id: "sess_debug_unsafe")
+
+    assert {:hibernate, %Session{} = session, %AgentSnapshot{} = snapshot} =
+             Harness.run_session(session, "Refund order_456",
+               llm: refund_llm("order_456"),
+               operations: refund_operations(self())
+             )
+
+    interrupt_id = snapshot.turn_state.pending_interrupt.id
+    approval = Review.Response.approve(interrupt_id)
+
+    assert {:ok, %Session{} = session, %Turn.Result{content: "Refund refund_456 is queued."}} =
+             Harness.resume_session(session,
+               approval: approval,
+               llm: refund_llm("order_456"),
+               operations: refund_operations(self())
+             )
+
+    assert_receive {:refund_called, %{"order_id" => "order_456"}, :unsafe_once}
+
+    assert {:ok,
+            %RequestSummary{
+              status: :finished,
+              operation_names: ["refund_order"],
+              replay_diagnostics: %ReplayDiagnostics{
+                status: :complete,
+                unsafe_effects: [%{idempotency: :unsafe_once}],
+                warnings: warnings
+              }
+            }} = Debug.latest(session)
+
+    assert "Some unsafe_once effects are not replay-safe." in warnings
+
+    assert {:ok, %ReplayDiagnostics{status: :complete, unsafe_effects: [_unsafe]}} =
+             Harness.Replay.diagnose(session)
+  end
+
+  defp account_operations do
+    test_pid = self()
+
+    LocalOperations.operations(%{
+      "account_lookup" => fn intent, _journal ->
+        arguments = Jidoka.Schema.get_key(intent.payload, :arguments)
+        account_id = arguments["account_id"]
+        send(test_pid, {:account_lookup_called, account_id})
+        {:ok, %{account_id: account_id, plan: "Pro", seats: 8}}
+      end
+    })
+  end
+
+  defp account_llm(account_id) do
+    fn _intent, %Effect.Journal{} = journal ->
+      case count_results(journal, :llm) do
+        0 ->
+          {:ok,
+           %{
+             type: :operation,
+             name: "account_lookup",
+             arguments: %{"account_id" => account_id},
+             metadata: %{usage: %{input_tokens: 2, output_tokens: 1, total_tokens: 3}}
+           }}
+
+        _count ->
+          {:ok,
+           %{
+             type: :final,
+             content: "Account #{account_id} is on the Pro plan.",
+             metadata: %{usage: %{input_tokens: 5, output_tokens: 4, total_tokens: 9}}
+           }}
+      end
+    end
+  end
+
+  defp refund_spec do
+    Agent.Spec.new!(
+      id: "debug_refund_agent",
+      instructions: "Use refund_order when refunds are requested.",
+      model: %{provider: :test, id: "model"},
+      operations: [
+        Operation.new!(
+          name: "refund_order",
+          description: "Starts a refund.",
+          idempotency: :unsafe_once
+        )
+      ],
+      controls:
+        Controls.new!(
+          operations: [
+            %{control: RequireRefundReviewControl, match: %{name: "refund_order"}}
+          ]
+        ),
+      runtime_defaults: %{max_model_turns: 4}
+    )
+  end
+
+  defp refund_llm(order_id) do
+    fn _intent, %Effect.Journal{} = journal ->
+      case count_results(journal, :llm) do
+        0 ->
+          {:ok,
+           %{
+             type: :operation,
+             name: "refund_order",
+             arguments: %{"order_id" => order_id}
+           }}
+
+        _count ->
+          {:ok, %{type: :final, content: "Refund refund_456 is queued."}}
+      end
+    end
+  end
+
+  defp refund_operations(test_pid) do
+    LocalOperations.operations(%{
+      "refund_order" => fn intent, _journal ->
+        arguments = Jidoka.Schema.get_key(intent.payload, :arguments)
+        send(test_pid, {:refund_called, arguments, intent.idempotency})
+        {:ok, %{"refund_id" => "refund_456", "order_id" => arguments["order_id"]}}
+      end
+    })
+  end
+end

--- a/test/jidoka/debug_test.exs
+++ b/test/jidoka/debug_test.exs
@@ -1,0 +1,143 @@
+defmodule Jidoka.DebugTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.Debug
+  alias Jidoka.Debug.{ReplayDiagnostics, RequestSummary}
+  alias Jidoka.Effect
+  alias Jidoka.Harness
+  alias Jidoka.Harness.Session
+  alias Jidoka.Runtime.AgentSnapshot
+  alias Jidoka.Turn
+
+  defmodule LookupAction do
+    use Jidoka.Action,
+      name: "debug_lookup",
+      description: "Returns deterministic debug data.",
+      schema: Zoi.object(%{id: Zoi.string()})
+
+    @impl true
+    def run(params, _context) do
+      {:ok, %{id: Map.get(params, :id), status: "active"}}
+    end
+  end
+
+  defmodule Agent do
+    use Jidoka.Agent
+
+    agent :debug_agent do
+      model %{provider: :test, id: "debug-model"}
+      instructions "Use debug_lookup before answering."
+    end
+
+    tools do
+      action LookupAction
+    end
+  end
+
+  test "request summaries explain completed turns" do
+    assert {:ok, %Turn.Result{} = result} =
+             Agent.run_turn("Check D-100.", llm: &tool_loop_llm/2)
+
+    assert %{
+             debug: %{
+               request_id: request_id,
+               prompt: %{
+                 messages: messages,
+                 operation_names: ["debug_lookup"]
+               }
+             }
+           } = result.metadata
+
+    assert Enum.map(messages, & &1.role) == [:system, :user, :tool]
+
+    assert {:ok,
+            %RequestSummary{
+              request_id: ^request_id,
+              agent_id: "debug_agent",
+              status: :finished,
+              model: "test:debug-model",
+              input: "Check D-100.",
+              content: "D-100 is active.",
+              operation_names: ["debug_lookup"],
+              operation_results: [%{operation: "debug_lookup"}],
+              replay_diagnostics: %ReplayDiagnostics{status: :complete}
+            } = summary} = Debug.request(result)
+
+    assert Enum.any?(summary.timeline, &(&1.event == :turn_finished))
+    assert summary.prompt.message_count == 3
+    assert summary.usage.llm_calls == 2
+  end
+
+  test "session request summaries include session id and replay diagnostics" do
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(Agent.spec(), session_id: "sess_debug")
+
+    assert {:ok, %Session{} = session, %Turn.Result{} = result} =
+             Harness.run_session(session, "Check D-100.",
+               llm: &tool_loop_llm/2,
+               operations: Jidoka.Runtime.JidoActions.operations([LookupAction])
+             )
+
+    assert {:ok,
+            %RequestSummary{
+              session_id: "sess_debug",
+              request_id: request_id,
+              replay_diagnostics: %ReplayDiagnostics{status: :complete}
+            }} = Debug.latest(session)
+
+    assert request_id == result.metadata.debug.request_id
+
+    assert {:ok, %ReplayDiagnostics{status: :complete, intent_count: 3, result_count: 3}} =
+             Harness.Replay.diagnose(session)
+  end
+
+  test "snapshot diagnostics flag incomplete pending effects" do
+    assert {:hibernate, %AgentSnapshot{} = snapshot} =
+             Agent.run_turn("Pause after prompt.", llm: &tool_loop_llm/2, checkpoint: :after_prompt)
+
+    assert {:ok,
+            %RequestSummary{
+              status: :running,
+              replay_diagnostics: %ReplayDiagnostics{
+                status: :incomplete,
+                missing_effect_results: [_missing],
+                warnings: warnings
+              }
+            }} = Debug.request(snapshot)
+
+    assert "Some effect intents do not have recorded results." in warnings
+  end
+
+  test "Kino debug_request renders without requiring Kino" do
+    assert {:ok, result} = Agent.run_turn("Check D-100.", llm: &tool_loop_llm/2)
+
+    assert {:ok, %RequestSummary{operation_names: ["debug_lookup"]}} =
+             Jidoka.Kino.debug_request(result)
+  end
+
+  defp tool_loop_llm(_intent, %Effect.Journal{} = journal) do
+    llm_calls =
+      journal.results
+      |> Map.values()
+      |> Enum.count(&(&1.kind == :llm))
+
+    case llm_calls do
+      0 ->
+        {:ok,
+         %{
+           type: :operation,
+           name: "debug_lookup",
+           arguments: %{"id" => "D-100"},
+           metadata: %{usage: %{input_tokens: 1, output_tokens: 1, total_tokens: 2}}
+         }}
+
+      1 ->
+        {:ok,
+         %{
+           type: :final,
+           content: "D-100 is active.",
+           metadata: %{usage: %{input_tokens: 1, output_tokens: 1, total_tokens: 2}}
+         }}
+    end
+  end
+end

--- a/test/jidoka/debug_test.exs
+++ b/test/jidoka/debug_test.exs
@@ -4,6 +4,7 @@ defmodule Jidoka.DebugTest do
   alias Jidoka.Debug
   alias Jidoka.Debug.{ReplayDiagnostics, RequestSummary}
   alias Jidoka.Effect
+  alias Jidoka.Event
   alias Jidoka.Harness
   alias Jidoka.Harness.Session
   alias Jidoka.Runtime.AgentSnapshot
@@ -106,6 +107,168 @@ defmodule Jidoka.DebugTest do
             }} = Debug.request(snapshot)
 
     assert "Some effect intents do not have recorded results." in warnings
+  end
+
+  test "request summaries handle common result and error tuples" do
+    assert {:ok, %Turn.Result{} = result} =
+             Agent.run_turn("Check D-100.", llm: &tool_loop_llm/2)
+
+    assert {:ok, %RequestSummary{status: :finished, session_id: nil}} =
+             Debug.request({:ok, result})
+
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(Agent.spec(), session_id: "sess_debug_tuple")
+
+    assert {:ok, %RequestSummary{status: :finished, session_id: "sess_debug_tuple"}} =
+             Debug.request({:ok, session, result})
+
+    assert {:error, :boom} = Debug.request({:error, :boom})
+
+    assert {:error, {:unsupported_debug_request_target, :not_debuggable}} =
+             Debug.request(:not_debuggable)
+  end
+
+  test "request summaries handle hibernate tuples and replay projections" do
+    assert {:hibernate, %AgentSnapshot{} = snapshot} =
+             Agent.run_turn("Pause after prompt.", llm: &tool_loop_llm/2, checkpoint: :after_prompt)
+
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(Agent.spec(), session_id: "sess_snapshot_tuple")
+
+    session =
+      session
+      |> Session.put_request(snapshot.turn_state.request)
+      |> Session.put_snapshot(snapshot)
+
+    assert {:ok,
+            %RequestSummary{
+              status: :running,
+              session_id: nil,
+              replay_diagnostics: %ReplayDiagnostics{status: :incomplete}
+            }} = Debug.request({:hibernate, snapshot})
+
+    assert {:ok,
+            %RequestSummary{
+              status: :running,
+              session_id: "sess_snapshot_tuple",
+              replay_diagnostics: %ReplayDiagnostics{status: :incomplete}
+            }} = Debug.request({:hibernate, session, snapshot})
+
+    assert {:ok, replay} = Harness.replay(session)
+
+    assert {:ok,
+            %RequestSummary{
+              session_id: "sess_snapshot_tuple",
+              status: :hibernated,
+              replay_diagnostics: %ReplayDiagnostics{status: :incomplete}
+            }} = Debug.request(replay)
+  end
+
+  test "session request summaries fall back to stored request data" do
+    assert {:ok, %Session{} = session} =
+             Harness.start_session(Agent.spec(), session_id: "sess_request_only")
+
+    request =
+      Turn.Request.new!(
+        input: "Queued question.",
+        request_id: "turn_request_only",
+        context: %{"region" => "us", tenant_id: "acme"}
+      )
+
+    session = Session.put_request(session, request)
+
+    assert {:ok,
+            %RequestSummary{
+              request_id: "turn_request_only",
+              session_id: "sess_request_only",
+              status: :running,
+              input: "Queued question.",
+              context_keys: ["region", "tenant_id"],
+              replay_diagnostics: %ReplayDiagnostics{status: :complete}
+            }} = Debug.request(session, request_id: "turn_request_only")
+  end
+
+  test "diagnostics flag failed effect results and failed timeline events" do
+    intent =
+      Effect.Intent.new(
+        :operation,
+        %{name: "debug_lookup", arguments: %{"id" => "D-500"}, request_id: "turn_failed"},
+        idempotency: :unsafe_once
+      )
+
+    journal =
+      Effect.Journal.new!()
+      |> Effect.Journal.put_intent(intent)
+      |> Effect.Journal.put_result(Effect.Result.error(intent, %{reason: "lookup failed"}))
+
+    assert {:ok,
+            %ReplayDiagnostics{
+              status: :failed,
+              intent_count: 1,
+              result_count: 1,
+              failed_effect_results: [%{intent_id: intent_id}],
+              unsafe_effects: [%{idempotency: :unsafe_once}],
+              warnings: journal_warnings
+            }} = Debug.diagnose(journal)
+
+    assert intent_id == intent.id
+    assert "Some effect results failed." in journal_warnings
+    assert "Some unsafe_once effects are not replay-safe." in journal_warnings
+
+    failed_event =
+      Event.build(:turn_failed, [],
+        agent_id: "debug_agent",
+        request_id: "turn_failed",
+        error: %{reason: "lookup failed"}
+      )
+
+    replay =
+      Harness.Replay.new!(
+        agent_id: "debug_agent",
+        status: :error,
+        timeline: [Jidoka.project(failed_event)],
+        journal: Jidoka.project(journal)
+      )
+
+    assert {:ok,
+            %ReplayDiagnostics{
+              status: :failed,
+              failed_events: [%{event: :turn_failed}],
+              warnings: replay_warnings
+            }} = Debug.diagnose(replay)
+
+    assert "Timeline contains failed events." in replay_warnings
+
+    assert {:error, {:unsupported_replay_diagnostics_target, :not_replayable}} =
+             Debug.diagnose(:not_replayable)
+  end
+
+  test "debug data contracts validate and normalize attrs" do
+    assert ReplayDiagnostics.statuses() == [:complete, :waiting, :failed, :incomplete]
+
+    assert {:ok, %ReplayDiagnostics{status: :waiting, warnings: ["Human review is still pending."]}} =
+             ReplayDiagnostics.new(
+               status: :waiting,
+               warnings: ["Human review is still pending."]
+             )
+
+    assert {:ok,
+            %RequestSummary{
+              request_id: "turn_contract",
+              context_keys: ["tenant"],
+              replay_diagnostics: %ReplayDiagnostics{status: :complete}
+            }} =
+             RequestSummary.new(%{
+               "request_id" => "turn_contract",
+               "context_keys" => ["tenant"],
+               "replay_diagnostics" => %{status: :complete}
+             })
+
+    assert {:error, _reason} = ReplayDiagnostics.new(status: :unknown)
+
+    assert_raise ArgumentError, ~r/invalid debug request summary/, fn ->
+      RequestSummary.new!(request_id: "")
+    end
   end
 
   test "Kino debug_request renders without requiring Kino" do


### PR DESCRIPTION
## Summary
- add Jidoka.Debug request summaries and replay diagnostics
- capture prompt/debug metadata in Turn.Result without storing full context maps
- surface debug summaries through inspection, projections, Kino, and guides
- add focused tests for completed turns, sessions, hibernated snapshots, and Kino rendering

## Verification
- mix test test/jidoka/debug_test.exs test/jidoka/inspection_test.exs test/jidoka/kino_test.exs test/jidoka/usage_test.exs
- mix test
- mix q