### PR TITLE
Enforce atom-keyed event data

### DIFF
--- a/lib/jidoka/event.ex
+++ b/lib/jidoka/event.ex
@@ -88,6 +88,7 @@ defmodule Jidoka.Event do
             },
             coerce: true
           )
+          |> Zoi.refine({__MODULE__, :validate_data_keys, []})
 
   @type data :: %{optional(atom()) => term()}
   @type t :: unquote(Zoi.type_spec(@schema))
@@ -102,12 +103,7 @@ defmodule Jidoka.Event do
   def events, do: Map.keys(@event_defaults)
 
   @spec new(keyword() | map()) :: {:ok, t()} | {:error, term()}
-  def new(attrs) do
-    with {:ok, %__MODULE__{} = event} <- Schema.parse(@schema, attrs),
-         :ok <- validate_data_keys(event) do
-      {:ok, event}
-    end
-  end
+  def new(attrs), do: Schema.parse(@schema, attrs)
 
   @spec new!(keyword() | map()) :: t()
   def new!(attrs) do
@@ -159,10 +155,12 @@ defmodule Jidoka.Event do
     |> Map.new()
   end
 
-  defp validate_data_keys(%__MODULE__{data: data}) when is_map(data) do
+  @doc false
+  @spec validate_data_keys(t(), keyword()) :: :ok | {:error, String.t()}
+  def validate_data_keys(%__MODULE__{data: data}, _opts \\ []) when is_map(data) do
     case Enum.find(Map.keys(data), &(not is_atom(&1))) do
       nil -> :ok
-      key -> {:error, {:invalid_event_data_key, key}}
+      key -> {:error, "event data keys must be atoms, got: #{inspect(key)}"}
     end
   end
 end

--- a/lib/jidoka/event.ex
+++ b/lib/jidoka/event.ex
@@ -89,6 +89,7 @@ defmodule Jidoka.Event do
             coerce: true
           )
 
+  @type data :: %{optional(atom()) => term()}
   @type t :: unquote(Zoi.type_spec(@schema))
   @enforce_keys Zoi.Struct.enforce_keys(@schema)
   defstruct Zoi.Struct.struct_fields(@schema)
@@ -101,10 +102,20 @@ defmodule Jidoka.Event do
   def events, do: Map.keys(@event_defaults)
 
   @spec new(keyword() | map()) :: {:ok, t()} | {:error, term()}
-  def new(attrs), do: Schema.parse(@schema, attrs)
+  def new(attrs) do
+    with {:ok, %__MODULE__{} = event} <- Schema.parse(@schema, attrs),
+         :ok <- validate_data_keys(event) do
+      {:ok, event}
+    end
+  end
 
   @spec new!(keyword() | map()) :: t()
-  def new!(attrs), do: Schema.parse!(@schema, attrs, "event")
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, event} -> event
+      {:error, reason} -> raise ArgumentError, "invalid event: #{inspect(reason)}"
+    end
+  end
 
   @doc "Builds a core event with defaults for known Jidoka event names."
   @spec build(atom(), list(), keyword() | map()) :: t()
@@ -146,5 +157,12 @@ defmodule Jidoka.Event do
       {_key, _value} -> false
     end)
     |> Map.new()
+  end
+
+  defp validate_data_keys(%__MODULE__{data: data}) when is_map(data) do
+    case Enum.find(Map.keys(data), &(not is_atom(&1))) do
+      nil -> :ok
+      key -> {:error, {:invalid_event_data_key, key}}
+    end
   end
 end

--- a/lib/jidoka/runtime/agent_snapshot.ex
+++ b/lib/jidoka/runtime/agent_snapshot.ex
@@ -7,6 +7,7 @@ defmodule Jidoka.Runtime.AgentSnapshot do
   """
 
   alias Jidoka.Context
+  alias Jidoka.Event
   alias Jidoka.Id
   alias Jidoka.Runtime.Review
   alias Jidoka.Schema
@@ -42,6 +43,11 @@ defmodule Jidoka.Runtime.AgentSnapshot do
 
   @spec new(keyword() | map()) :: {:ok, t()} | {:error, term()}
   def new(attrs) do
+    attrs =
+      attrs
+      |> Schema.normalize_attrs()
+      |> normalize_portable_events()
+
     with {:ok, %__MODULE__{} = snapshot} <- Schema.parse(@schema, attrs),
          :ok <- validate_schema_version(snapshot) do
       {:ok, snapshot}
@@ -155,6 +161,67 @@ defmodule Jidoka.Runtime.AgentSnapshot do
   defp validate_schema_version(%__MODULE__{schema_version: version}) do
     {:error, {:unsupported_snapshot_schema_version, version, @schema_version}}
   end
+
+  defp normalize_portable_events(%{turn_state: turn_state} = attrs) do
+    %{attrs | turn_state: normalize_turn_state_events(turn_state)}
+  end
+
+  defp normalize_portable_events(%{"turn_state" => turn_state} = attrs) do
+    %{attrs | "turn_state" => normalize_turn_state_events(turn_state)}
+  end
+
+  defp normalize_portable_events(attrs), do: attrs
+
+  defp normalize_turn_state_events(%Turn.State{} = state), do: state
+
+  defp normalize_turn_state_events(%{} = turn_state) do
+    turn_state
+    |> normalize_event_list(:events)
+    |> normalize_event_list("events")
+  end
+
+  defp normalize_turn_state_events(turn_state), do: turn_state
+
+  defp normalize_event_list(%{} = turn_state, key) do
+    case Map.fetch(turn_state, key) do
+      {:ok, events} when is_list(events) ->
+        Map.put(turn_state, key, Enum.map(events, &normalize_event/1))
+
+      _other ->
+        turn_state
+    end
+  end
+
+  defp normalize_event(%Event{} = event), do: event
+
+  defp normalize_event(%{} = event) do
+    event
+    |> normalize_event_data(:data)
+    |> normalize_event_data("data")
+  end
+
+  defp normalize_event(event), do: event
+
+  defp normalize_event_data(%{} = event, key) do
+    case Map.fetch(event, key) do
+      {:ok, data} when is_map(data) -> Map.put(event, key, normalize_existing_atom_keys(data))
+      _other -> event
+    end
+  end
+
+  defp normalize_existing_atom_keys(data) do
+    Map.new(data, fn {key, value} -> {existing_atom_key(key), value} end)
+  end
+
+  defp existing_atom_key(key) when is_atom(key), do: key
+
+  defp existing_atom_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
+
+  defp existing_atom_key(key), do: key
 
   defp snapshot_metadata(%Turn.State{} = state, opts) do
     opts

--- a/lib/jidoka/stream.ex
+++ b/lib/jidoka/stream.ex
@@ -57,7 +57,7 @@ defmodule Jidoka.Stream do
   @doc "Extracts a content delta from an `:llm_delta` event."
   @spec text_delta(Event.t()) :: String.t() | nil
   def text_delta(%Event{event: :llm_delta, data: data}) when is_map(data) do
-    if delta_kind(data) in [:content, "content", nil], do: string_value(data, :delta)
+    if Map.get(data, :chunk_type) in [:content, nil], do: string_value(data, :delta)
   end
 
   def text_delta(_event), do: nil
@@ -65,8 +65,7 @@ defmodule Jidoka.Stream do
   @doc "Extracts a thinking/reasoning delta from an `:llm_delta` event."
   @spec thinking_delta(Event.t()) :: String.t() | nil
   def thinking_delta(%Event{event: :llm_delta, data: data}) when is_map(data) do
-    if delta_kind(data) in [:thinking, :reasoning, "thinking", "reasoning"],
-      do: string_value(data, :delta)
+    if Map.get(data, :chunk_type) in [:thinking, :reasoning], do: string_value(data, :delta)
   end
 
   def thinking_delta(_event), do: nil
@@ -141,10 +140,8 @@ defmodule Jidoka.Stream do
 
   defp emit_to_callback(_event, _callback), do: :ok
 
-  defp delta_kind(data), do: Map.get(data, :chunk_type, Map.get(data, "chunk_type"))
-
   defp string_value(data, key) do
-    case Map.get(data, key, Map.get(data, Atom.to_string(key))) do
+    case Map.get(data, key) do
       value when is_binary(value) -> value
       _other -> nil
     end

--- a/lib/jidoka/turn/state/operation_planner.ex
+++ b/lib/jidoka/turn/state/operation_planner.ex
@@ -96,7 +96,7 @@ defmodule Jidoka.Turn.State.OperationPlanner do
               arguments: arguments,
               request_id: state.request.request_id,
               loop_index: state.loop_index,
-              metadata: %{"batch_index" => index, "batch_size" => batch_size}
+              metadata: %{batch_index: index, batch_size: batch_size}
             )
 
           {:ok, operation_effect(state, operation, operation_request, index, batch_size)}
@@ -146,7 +146,7 @@ defmodule Jidoka.Turn.State.OperationPlanner do
         arguments
       ])
 
-    {idempotency_key, %{"batch_index" => index, "batch_size" => batch_size}}
+    {idempotency_key, %{batch_index: index, batch_size: batch_size}}
   end
 
   defp effect_operation_name(%Effect.Intent{payload: payload}) do

--- a/test/jidoka/event_test.exs
+++ b/test/jidoka/event_test.exs
@@ -38,6 +38,14 @@ defmodule Jidoka.EventTest do
              Event.new(event: :turn_failed, data: %{reason: :cancelled})
   end
 
+  test "accepts string-keyed event attrs while enforcing atom-keyed data" do
+    assert {:ok, %Event{event: :turn_failed, data: %{reason: :cancelled}}} =
+             Event.new(%{"event" => "turn_failed", "data" => %{reason: :cancelled}})
+
+    assert {:error, {:invalid_event_data_key, "reason"}} =
+             Event.new(%{"event" => "turn_failed", "data" => %{"reason" => :cancelled}})
+  end
+
   test "accepts string-keyed maps nested inside event data values" do
     assert {:ok, %Event{data: %{payload: %{"external" => true}}}} =
              Event.new(event: :turn_failed, data: %{payload: %{"external" => true}})
@@ -51,6 +59,12 @@ defmodule Jidoka.EventTest do
   test "raises with an invalid event label for string-keyed event data" do
     assert_raise ArgumentError, ~r/invalid event: \{:invalid_event_data_key, "reason"\}/, fn ->
       Event.new!(event: :turn_failed, data: %{"reason" => :cancelled})
+    end
+  end
+
+  test "build enforces atom-keyed event data" do
+    assert_raise ArgumentError, ~r/invalid event: \{:invalid_event_data_key, "reason"\}/, fn ->
+      Event.build(:turn_failed, [], data: %{"reason" => :cancelled})
     end
   end
 end

--- a/test/jidoka/event_test.exs
+++ b/test/jidoka/event_test.exs
@@ -32,4 +32,20 @@ defmodule Jidoka.EventTest do
     assert_receive {:jidoka_turn_event, %Event{event: :turn_failed, data: %{reason: :cancelled}} = event}
     assert Event.cancelled?(event)
   end
+
+  test "accepts atom-keyed event data" do
+    assert {:ok, %Event{data: %{reason: :cancelled}}} =
+             Event.new(event: :turn_failed, data: %{reason: :cancelled})
+  end
+
+  test "rejects string-keyed event data" do
+    assert {:error, {:invalid_event_data_key, "reason"}} =
+             Event.new(event: :turn_failed, data: %{"reason" => :cancelled})
+  end
+
+  test "raises with an invalid event label for string-keyed event data" do
+    assert_raise ArgumentError, ~r/invalid event: \{:invalid_event_data_key, "reason"\}/, fn ->
+      Event.new!(event: :turn_failed, data: %{"reason" => :cancelled})
+    end
+  end
 end

--- a/test/jidoka/event_test.exs
+++ b/test/jidoka/event_test.exs
@@ -2,6 +2,7 @@ defmodule Jidoka.EventTest do
   use ExUnit.Case, async: true
 
   alias Jidoka.Event
+  alias Jidoka.Turn
 
   test "recognizes canonical cancelled turn failure events" do
     assert Event.cancelled?(Event.build(:turn_failed, [], data: %{reason: :cancelled}))
@@ -42,8 +43,10 @@ defmodule Jidoka.EventTest do
     assert {:ok, %Event{event: :turn_failed, data: %{reason: :cancelled}}} =
              Event.new(%{"event" => "turn_failed", "data" => %{reason: :cancelled}})
 
-    assert {:error, {:invalid_event_data_key, "reason"}} =
+    assert {:error, errors} =
              Event.new(%{"event" => "turn_failed", "data" => %{"reason" => :cancelled}})
+
+    assert invalid_event_data_key_error?(errors, "reason")
   end
 
   test "accepts string-keyed maps nested inside event data values" do
@@ -52,19 +55,38 @@ defmodule Jidoka.EventTest do
   end
 
   test "rejects string-keyed event data" do
-    assert {:error, {:invalid_event_data_key, "reason"}} =
-             Event.new(event: :turn_failed, data: %{"reason" => :cancelled})
+    assert {:error, errors} = Event.new(event: :turn_failed, data: %{"reason" => :cancelled})
+    assert invalid_event_data_key_error?(errors, "reason")
   end
 
   test "raises with an invalid event label for string-keyed event data" do
-    assert_raise ArgumentError, ~r/invalid event: \{:invalid_event_data_key, "reason"\}/, fn ->
+    assert_raise ArgumentError, ~r/event data keys must be atoms/, fn ->
       Event.new!(event: :turn_failed, data: %{"reason" => :cancelled})
     end
   end
 
   test "build enforces atom-keyed event data" do
-    assert_raise ArgumentError, ~r/invalid event: \{:invalid_event_data_key, "reason"\}/, fn ->
+    assert_raise ArgumentError, ~r/event data keys must be atoms/, fn ->
       Event.build(:turn_failed, [], data: %{"reason" => :cancelled})
     end
   end
+
+  test "event schema consumers enforce atom-keyed event data" do
+    assert {:error, errors} =
+             Turn.Transition.new(%{},
+               events: [%{event: :turn_failed, data: %{"reason" => :cancelled}}]
+             )
+
+    assert invalid_event_data_key_error?(errors, "reason")
+  end
+
+  defp invalid_event_data_key_error?(errors, key) when is_list(errors) do
+    Enum.any?(errors, &invalid_event_data_key_error?(&1, key))
+  end
+
+  defp invalid_event_data_key_error?(%Zoi.Error{message: message}, key) do
+    message == "event data keys must be atoms, got: #{inspect(key)}"
+  end
+
+  defp invalid_event_data_key_error?(_error, _key), do: false
 end

--- a/test/jidoka/event_test.exs
+++ b/test/jidoka/event_test.exs
@@ -38,6 +38,11 @@ defmodule Jidoka.EventTest do
              Event.new(event: :turn_failed, data: %{reason: :cancelled})
   end
 
+  test "accepts string-keyed maps nested inside event data values" do
+    assert {:ok, %Event{data: %{payload: %{"external" => true}}}} =
+             Event.new(event: :turn_failed, data: %{payload: %{"external" => true}})
+  end
+
   test "rejects string-keyed event data" do
     assert {:error, {:invalid_event_data_key, "reason"}} =
              Event.new(event: :turn_failed, data: %{"reason" => :cancelled})

--- a/test/jidoka/stream_test.exs
+++ b/test/jidoka/stream_test.exs
@@ -14,6 +14,15 @@ defmodule Jidoka.StreamTest do
     assert Stream.thinking_delta(thinking) == "checking"
   end
 
+  test "delta helpers ignore string-keyed event data" do
+    event =
+      Event.new!(event: :llm_delta, data: %{chunk_type: :content, delta: "hello"})
+      |> Map.put(:data, %{"chunk_type" => :content, "delta" => "hello"})
+
+    assert Stream.text_delta(event) == nil
+    assert Stream.thinking_delta(event) == nil
+  end
+
   test "mailbox stream filters by request id and stops on terminal events" do
     request_id = "req_stream_events"
 

--- a/test/jidoka/stream_test.exs
+++ b/test/jidoka/stream_test.exs
@@ -6,6 +6,14 @@ defmodule Jidoka.StreamTest do
   alias Jidoka.Stream
   alias Jidoka.Turn
 
+  test "delta helpers read atom-keyed event data" do
+    content = Event.new!(event: :llm_delta, data: %{chunk_type: :content, delta: "hello"})
+    thinking = Event.new!(event: :llm_delta, data: %{chunk_type: :thinking, delta: "checking"})
+
+    assert Stream.text_delta(content) == "hello"
+    assert Stream.thinking_delta(thinking) == "checking"
+  end
+
   test "mailbox stream filters by request id and stops on terminal events" do
     request_id = "req_stream_events"
 

--- a/test/jidoka/turn/state_test.exs
+++ b/test/jidoka/turn/state_test.exs
@@ -69,8 +69,8 @@ defmodule Jidoka.Turn.StateTest do
     assert [first, second] = next_state.pending_effects
     assert first.id != second.id
     assert first.idempotency_key != second.idempotency_key
-    assert first.metadata == %{"batch_index" => 0, "batch_size" => 2}
-    assert second.metadata == %{"batch_index" => 1, "batch_size" => 2}
+    assert first.metadata == %{batch_index: 0, batch_size: 2}
+    assert second.metadata == %{batch_index: 1, batch_size: 2}
   end
 
   test "keeps duplicate operation calls distinct inside a batch" do


### PR DESCRIPTION
## Summary

- require top-level `Jidoka.Event.data` keys to be atoms
- update internal operation-batch metadata to follow that event-data contract
- tighten stream delta helpers to read atom-keyed event data only
- add focused event and stream tests for the contract

## Use case

Jidoka events are internal runtime/harness data, not decoded JSON payloads. Consumers should be able to pattern match on event data without also defending against string-key variants for the same field.

This PR makes that contract explicit for `Jidoka.Event`: top-level event `data` must be atom-keyed. JSON-shaped maps can still exist inside payload values where appropriate, but the event data envelope has one key convention.

Two internal call sites are updated to follow that contract:

- operation batch metadata now uses atom keys (`:batch_index`, `:batch_size`)
- stream delta helpers now read atom-keyed `:chunk_type` and `:delta` fields rather than accepting both atom and string variants

## Tests

- `mix test test/jidoka/event_test.exs test/jidoka/stream_test.exs test/jidoka/turn/state_test.exs test/integration/parallel_tool_calling_integration_test.exs test/integration/approval_sugar_integration_test.exs`
- `mix test`
