### PR TITLE
fix: install default runtime capabilities for turns

### DIFF
--- a/guides/runtime-capabilities-internals.md
+++ b/guides/runtime-capabilities-internals.md
@@ -141,9 +141,10 @@ defp missing_operations_capability(_intent, _journal, _ctx),
 
 Two properties are load-bearing:
 
-- **`llm` has no default.** A turn that interprets an `:llm` intent without a
-  user-supplied LLM capability fails closed at `Capabilities.new/1`, not
-  inside the interpreter.
+- **`llm` is required at the capability layer.** Facade and harness calls install
+  a ReqLLM-backed default from the agent spec when no `llm:` is supplied, but a
+  raw `Capabilities.new/1` call still fails closed without an explicit LLM
+  capability.
 - **`operations` defaults to a closed adapter.** An agent without operations
   still gets a function in the struct; calling it returns
   `{:error, :missing_operations_capability}` which the interpreter normalizes

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -163,7 +163,7 @@ trace.
 
 | Symptom | Likely Cause | Fix |
 | --- | --- | --- |
-| `{:error, :missing_operations_capability}` | Agent has operations but call omitted `operations:` | Pass `operations: Jidoka.Runtime.JidoActions.operations(actions)` or `Jidoka.Runtime.LocalOperations.operations(handlers)`. |
+| `{:error, :missing_operations_capability}` | Data-built agent has operations but call omitted `operations:` | Pass `operations: Jidoka.Runtime.JidoActions.operations(actions)` or `Jidoka.Runtime.LocalOperations.operations(handlers)`. DSL agents install their declared tool capability by default. |
 | `{:error, {:missing_jido_action, name}}` | Decision asked for an action not registered in `Jido.Action` list | Add the action to the operations capability or rename in the prompt. |
 | `{:error, {:missing_operation_handler, name}}` | Decision asked for a local operation not in the handler map | Add the handler or update the prompt. |
 | `{:error, {:unsupported_effect_kind, kind}}` | Adapter was called with an intent kind it does not handle | Route only `:operation` intents to the operation adapter; route `:llm` intents to the LLM adapter. |

--- a/lib/jidoka.ex
+++ b/lib/jidoka.ex
@@ -36,8 +36,8 @@ defmodule Jidoka do
   alias Jidoka.Runtime.AgentSnapshot
   alias Jidoka.Turn
 
-  @type agent_input :: Agent.Spec.t() | keyword() | map()
-  @type plan_input :: Agent.Spec.t() | Turn.Plan.t() | keyword() | map()
+  @type agent_input :: module() | Agent.Spec.t() | keyword() | map()
+  @type plan_input :: module() | Agent.Spec.t() | Turn.Plan.t() | keyword() | map()
   @type request_input :: Turn.Request.t() | String.t() | keyword() | map()
   @type runtime_opts :: keyword()
   @type server_ref :: Jido.AgentServer.server()
@@ -266,10 +266,10 @@ defmodule Jidoka do
   @doc """
   Runs one agent turn through the Jidoka Runic spine.
 
-  This is the stable core runtime entrypoint. It accepts an `Agent.Spec` or
-  `Turn.Plan`, normalizes the request, runs pure workflow planning, interprets
-  external effects through explicit runtime capabilities, and returns a typed
-  result or snapshot.
+  This is the stable core runtime entrypoint. It accepts a DSL agent module,
+  `Agent.Spec`, or `Turn.Plan`, normalizes the request, runs pure workflow
+  planning, interprets external effects through explicit runtime capabilities,
+  and returns a typed result or snapshot.
 
   Use `turn/3` for deterministic tests with injected capabilities, live ReqLLM
   calls, process-hosted agents, controls, tools, hibernation, streaming, and

--- a/lib/jidoka/agent.ex
+++ b/lib/jidoka/agent.ex
@@ -225,7 +225,9 @@ defmodule Jidoka.Agent do
     end
   end
 
-  defp runtime_opts(agent_module, %Spec{} = spec, opts) do
+  @doc false
+  @spec runtime_opts(module(), Spec.t(), keyword()) :: keyword()
+  def runtime_opts(agent_module, %Spec{} = spec, opts) do
     opts
     |> Keyword.put(:operation_context, operation_context(agent_module, spec, opts))
     |> Keyword.put_new(

--- a/lib/jidoka/agent/spec.ex
+++ b/lib/jidoka/agent/spec.ex
@@ -58,8 +58,21 @@ defmodule Jidoka.Agent.Spec do
     end
   end
 
-  @spec from_input(t() | keyword() | map()) :: {:ok, t()} | {:error, term()}
+  @spec from_input(t() | module() | keyword() | map()) :: {:ok, t()} | {:error, term()}
   def from_input(%__MODULE__{} = spec), do: new(spec)
+
+  def from_input(agent_module) when is_atom(agent_module) do
+    cond do
+      Code.ensure_loaded?(agent_module) and function_exported?(agent_module, :spec, 0) ->
+        agent_module
+        |> apply(:spec, [])
+        |> new()
+
+      true ->
+        {:error, {:invalid_agent_spec_input, agent_module}}
+    end
+  end
+
   def from_input(input), do: new(input)
 
   @spec validate_context(t(), Jidoka.Context.t()) :: :ok | {:error, term()}

--- a/lib/jidoka/harness.ex
+++ b/lib/jidoka/harness.ex
@@ -17,6 +17,7 @@ defmodule Jidoka.Harness do
   alias Jidoka.Runtime.Capabilities
   alias Jidoka.Runtime.ReqLLM
   alias Jidoka.Runtime.TurnRunner
+  alias Jidoka.Schema
   alias Jidoka.Turn
 
   @type agent_input :: module() | Agent.Spec.t() | keyword() | map()
@@ -336,11 +337,23 @@ defmodule Jidoka.Harness do
         {:ok, capabilities}
 
       capability_attrs when is_list(capability_attrs) or is_map(capability_attrs) ->
-        Capabilities.new(capability_attrs)
+        capability_attrs
+        |> capability_attrs_with_defaults(opts)
+        |> Capabilities.new()
 
       nil ->
         Capabilities.new(opts)
     end
+  end
+
+  defp capability_attrs_with_defaults(capability_attrs, opts) do
+    [:llm, :operations]
+    |> Enum.reduce(Schema.normalize_attrs(capability_attrs), fn capability, attrs ->
+      case Keyword.fetch(opts, capability) do
+        {:ok, value} -> Schema.put_default(attrs, capability, value)
+        :error -> attrs
+      end
+    end)
   end
 
   defp request_opts(opts) do

--- a/lib/jidoka/harness.ex
+++ b/lib/jidoka/harness.ex
@@ -15,11 +15,12 @@ defmodule Jidoka.Harness do
   alias Jidoka.Memory
   alias Jidoka.Runtime.AgentSnapshot
   alias Jidoka.Runtime.Capabilities
+  alias Jidoka.Runtime.ReqLLM
   alias Jidoka.Runtime.TurnRunner
   alias Jidoka.Turn
 
-  @type agent_input :: Agent.Spec.t() | keyword() | map()
-  @type plan_input :: Agent.Spec.t() | Turn.Plan.t() | keyword() | map()
+  @type agent_input :: module() | Agent.Spec.t() | keyword() | map()
+  @type plan_input :: module() | Agent.Spec.t() | Turn.Plan.t() | keyword() | map()
   @type request_input :: Turn.Request.t() | String.t() | keyword() | map()
   @type runtime_opts :: keyword()
   @type session_input :: Session.t() | String.t()
@@ -36,6 +37,7 @@ defmodule Jidoka.Harness do
   @spec run_turn(plan_input(), request_input(), runtime_opts()) :: run_result()
   def run_turn(spec_or_plan, request_input, opts \\ []) do
     with {:ok, plan} <- plan(spec_or_plan),
+         opts = runtime_opts(plan, opts),
          {:ok, request} <- Turn.Request.from_input(request_input, request_opts(opts)),
          :ok <- Agent.Spec.validate_context(plan.spec, request.context),
          {:ok, memory} <- Memory.Runtime.recall(plan.spec, request, opts),
@@ -52,6 +54,7 @@ defmodule Jidoka.Harness do
   @spec resume(AgentSnapshot.t() | String.t(), runtime_opts()) :: run_result()
   def resume(snapshot_input, opts \\ []) do
     with {:ok, snapshot} <- AgentSnapshot.from_input(snapshot_input),
+         opts = runtime_opts(snapshot, opts),
          {:ok, capabilities} <- normalize_capabilities(opts) do
       TurnRunner.resume(snapshot, capabilities, opts)
     end
@@ -79,6 +82,7 @@ defmodule Jidoka.Harness do
     with {:ok, session} <- resolve_session(session_input, opts),
          :ok <- ensure_runnable_session(session),
          {:ok, plan} <- plan(session.spec),
+         opts = runtime_opts(plan, opts),
          {:ok, request} <- Turn.Request.from_input(request_input, request_opts(opts)),
          :ok <- Agent.Spec.validate_context(plan.spec, request.context),
          {:ok, memory} <-
@@ -108,6 +112,7 @@ defmodule Jidoka.Harness do
   def resume_session(session_input, opts \\ []) do
     with {:ok, session} <- resolve_session(session_input, opts),
          {:ok, snapshot} <- latest_snapshot(session),
+         opts = runtime_opts(snapshot, opts),
          {:ok, capabilities} <- normalize_capabilities(opts) do
       session
       |> resume_session_snapshot(snapshot, capabilities, opts)
@@ -274,6 +279,56 @@ defmodule Jidoka.Harness do
   end
 
   defp session_opts(opts), do: Keyword.take(opts, [:session_id, :id_generator, :metadata])
+
+  defp runtime_opts(%Turn.Plan{spec: %Agent.Spec{} = spec}, opts) do
+    runtime_opts(spec, opts)
+  end
+
+  defp runtime_opts(%AgentSnapshot{turn_state: %{spec: %Agent.Spec{} = spec}}, opts) do
+    runtime_opts(spec, opts)
+  end
+
+  defp runtime_opts(%Agent.Spec{} = spec, opts) do
+    case dsl_agent_module(spec) do
+      nil ->
+        Keyword.put_new(opts, :llm, ReqLLM.llm(default_llm_opts(spec, opts)))
+
+      agent_module ->
+        Agent.runtime_opts(agent_module, spec, opts)
+    end
+  end
+
+  defp dsl_agent_module(%Agent.Spec{metadata: metadata}) when is_map(metadata) do
+    metadata
+    |> Map.get("dsl_module", Map.get(metadata, :dsl_module))
+    |> existing_dsl_agent_module()
+  end
+
+  defp existing_dsl_agent_module(module_name) when is_binary(module_name) do
+    module =
+      module_name
+      |> String.trim()
+      |> module_atom()
+
+    if Code.ensure_loaded?(module) and function_exported?(module, :__jidoka_agent__, 0) do
+      module
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp existing_dsl_agent_module(_module_name), do: nil
+
+  defp module_atom("Elixir." <> _rest = module_name), do: String.to_existing_atom(module_name)
+  defp module_atom(module_name), do: String.to_existing_atom("Elixir." <> module_name)
+
+  defp default_llm_opts(%Agent.Spec{} = spec, opts) do
+    spec.generation
+    |> Agent.Spec.Generation.to_req_llm_opts()
+    |> Keyword.merge(Keyword.get(opts, :llm_opts, []))
+    |> Keyword.merge(Keyword.take(opts, [:stream, :stream_to, :on_event]))
+    |> Keyword.put_new(:model, spec.model)
+  end
 
   defp normalize_capabilities(opts) do
     case Keyword.get(opts, :capabilities) do

--- a/test/jidoka_test.exs
+++ b/test/jidoka_test.exs
@@ -114,6 +114,45 @@ defmodule JidokaTest do
     refute missing_llm_capability_error?(error)
   end
 
+  test "partial capability attrs keep default DSL operation capabilities" do
+    plan = Jidoka.plan!(TimeAgent)
+
+    assert {:ok, %Turn.Result{content: "Chicago is 09:30."}} =
+             Jidoka.turn(
+               plan,
+               Turn.Request.new!(input: "What time is it in Chicago?", context: %{test_pid: self()}),
+               capabilities: [llm: time_agent_llm()]
+             )
+
+    assert_receive {:local_time_called, "Chicago"}
+  end
+
+  test "partial capability attrs keep default ReqLLM capabilities" do
+    spec =
+      Agent.Spec.new!(
+        id: "partial_capability_agent",
+        instructions: "Use tools when useful.",
+        model: %{provider: :test, id: "model"},
+        operations: [
+          Operation.new!(
+            name: "weather",
+            description: "Looks up weather by city.",
+            idempotency: :idempotent
+          )
+        ]
+      )
+
+    operations =
+      LocalOperations.operations(%{
+        weather: fn _intent, _journal, _ctx -> {:ok, %{condition: "sunny"}} end
+      })
+
+    assert {:error, %Jidoka.Error.ExecutionError{} = error} =
+             Jidoka.turn(spec, "Weather in Paris?", capabilities: [operations: operations])
+
+    refute missing_llm_capability_error?(error)
+  end
+
   test "agent specs are normalized through Zoi schemas" do
     assert {:ok, %Agent.Spec{} = spec} =
              Agent.Spec.new(%{

--- a/test/jidoka_test.exs
+++ b/test/jidoka_test.exs
@@ -77,6 +77,43 @@ defmodule JidokaTest do
     assert {:ok, "echo"} = Jidoka.chat(spec, "Echo", capabilities: [llm: llm])
   end
 
+  test "top-level turn accepts DSL agent modules with their default operation capability" do
+    llm = time_agent_llm()
+
+    assert {:ok, %Turn.Result{content: "Chicago is 09:30."} = result} =
+             Jidoka.turn(
+               TimeAgent,
+               Turn.Request.new!(input: "What time is it in Chicago?", context: %{test_pid: self()}),
+               llm: llm
+             )
+
+    assert_receive {:local_time_called, "Chicago"}
+
+    assert [%{operation: "local_time", output: %{"canary" => "jidoka_dsl_tool_canary"}}] =
+             result.agent_state.operation_results
+  end
+
+  test "compiled DSL plans keep default runtime capabilities" do
+    plan = Jidoka.plan!(TimeAgent)
+    llm = time_agent_llm()
+
+    assert {:ok, %Turn.Result{content: "Chicago is 09:30."}} =
+             Jidoka.turn(
+               plan,
+               Turn.Request.new!(input: "What time is it in Chicago?", context: %{test_pid: self()}),
+               llm: llm
+             )
+
+    assert_receive {:local_time_called, "Chicago"}
+  end
+
+  test "compiled DSL plans install a default ReqLLM capability when llm is omitted" do
+    plan = Jidoka.plan!(TimeAgent)
+
+    assert {:error, %Jidoka.Error.ExecutionError{} = error} = Jidoka.turn(plan, "Hello")
+    refute missing_llm_capability_error?(error)
+  end
+
   test "agent specs are normalized through Zoi schemas" do
     assert {:ok, %Agent.Spec{} = spec} =
              Agent.Spec.new(%{
@@ -350,6 +387,28 @@ defmodule JidokaTest do
   defp count_results(%Effect.Journal{results: results}, kind) do
     Enum.count(results, fn {_id, %Effect.Result{kind: result_kind}} -> result_kind == kind end)
   end
+
+  defp time_agent_llm do
+    fn _intent, %Effect.Journal{} = journal, _ctx ->
+      case count_results(journal, :llm) do
+        0 -> {:ok, %{type: :operation, name: "local_time", arguments: %{"city" => "Chicago"}}}
+        1 -> {:ok, %{type: :final, content: "Chicago is 09:30."}}
+      end
+    end
+  end
+
+  defp missing_llm_capability_error?(%Jidoka.Error.ExecutionError{details: %{cause: cause}}) do
+    missing_llm_capability_cause?(cause)
+  end
+
+  defp missing_llm_capability_error?(_error), do: false
+
+  defp missing_llm_capability_cause?(errors) when is_list(errors) do
+    Enum.any?(errors, &missing_llm_capability_cause?/1)
+  end
+
+  defp missing_llm_capability_cause?(%Zoi.Error{path: [:llm]}), do: true
+  defp missing_llm_capability_cause?(_cause), do: false
 
   defp portable_map(%_{} = value), do: value |> Map.from_struct() |> portable_map()
 


### PR DESCRIPTION
## Summary

- Accept DSL agent modules anywhere an agent spec input is expected, so `Jidoka.turn(MyAgent, ...)` and `Jidoka.plan!(MyAgent)` use the compiled DSL spec.
- Install a ReqLLM-backed default LLM capability from the agent spec for direct harness/facade turns when `llm:` is omitted.
- Preserve DSL-declared operation defaults for compiled DSL specs/plans and update deterministic regression coverage.

## Root Cause

`MyAgent.run_turn/2` installed default ReqLLM and operation capabilities, but direct `Jidoka.turn/3` and `Jidoka.Harness.run_turn/3` over specs/plans only passed caller-provided capabilities into `Capabilities.new/1`. That made the documented full-turn path fail with `:llm is required`.

Fixes #24.

## Validation

- `mix format --check-formatted`
- `mix test`
- `mix compile --warnings-as-errors`