### PR TITLE
fix: project context at Jido action boundary

### DIFF
--- a/examples/_support/ex_unit_formatter.ex
+++ b/examples/_support/ex_unit_formatter.ex
@@ -24,7 +24,7 @@ defmodule JidokaExamples.ExUnitFormatter do
         test: %{
           file: relative_file(test.tags[:file]),
           line: test.tags[:line],
-          name: test.description || to_string(test.name)
+          name: Map.get(test, :description) || to_string(test.name)
         },
         duration_ms: duration_ms(test.time),
         failure: failure(test.state)

--- a/examples/_support/timeouts.ex
+++ b/examples/_support/timeouts.ex
@@ -2,7 +2,7 @@ defmodule JidokaExamples.Timeouts do
   @moduledoc false
 
   @budgets %{
-    compile: 120_000,
+    compile: 240_000,
     documentation: 120_000,
     example: 30_000,
     livebook: 30_000,

--- a/examples/_support/timeouts.ex
+++ b/examples/_support/timeouts.ex
@@ -6,7 +6,7 @@ defmodule JidokaExamples.Timeouts do
     documentation: 120_000,
     example: 30_000,
     livebook: 30_000,
-    showcase_compile: 60_000,
+    showcase_compile: 240_000,
     showcase_focused: 60_000,
     showcase_full: 120_000
   }

--- a/guides/ash-jido.md
+++ b/guides/ash-jido.md
@@ -31,12 +31,13 @@ defmodule MyApp.Support.Ticket do
     domain: MyApp.Support,
     extensions: [AshJido]
 
-  ash_jido do
-    expose [:read, :create]
-  end
-
   actions do
     defaults [:read, :create, :update]
+  end
+
+  jido do
+    action :read
+    action :create
   end
 end
 ```
@@ -186,9 +187,9 @@ context.
   )
 ```
 
-The `:ash_resource` capability forwards the public context (everything that is
-not stripped by a `forward_context: {:except, ...}` policy) into the generated
-Jido action's `context` argument.
+The `:ash_resource` capability projects caller-supplied context data into the
+plain map expected by each generated Jido action. Thus, `:actor` and `:tenant`
+are top-level keys in the action's `context` argument.
 
 ### Step 4: Import The Same Agent From YAML
 

--- a/lib/jidoka/browser/runtime.ex
+++ b/lib/jidoka/browser/runtime.ex
@@ -126,6 +126,12 @@ defmodule Jidoka.Browser.Runtime do
     |> allowlist_for(operation_name)
   end
 
+  defp allowlist_for(%{__jidoka__: _namespace} = context, operation_name) do
+    context
+    |> Jidoka.Context.get_runtime(:jidoka_spec)
+    |> allowlist_for(operation_name)
+  end
+
   defp allowlist_for(%{operations: operations}, operation_name) do
     operations
     |> Enum.find(&(&1.name == operation_name))

--- a/lib/jidoka/context.ex
+++ b/lib/jidoka/context.ex
@@ -232,7 +232,7 @@ defmodule Jidoka.Context do
   def to_action_context(%__MODULE__{} = context) do
     context
     |> data()
-    |> Map.drop([@action_context_namespace, Atom.to_string(@action_context_namespace)])
+    |> Map.drop([:__struct__, @action_context_namespace, Atom.to_string(@action_context_namespace)])
     |> Map.put(@action_context_namespace, %{context: context})
   end
 

--- a/lib/jidoka/context.ex
+++ b/lib/jidoka/context.ex
@@ -28,6 +28,7 @@ defmodule Jidoka.Context do
     :handoff
   ]
   @operation_idempotencies [:pure, :idempotent, :dedupe, :reconcile, :unsafe_once]
+  @action_context_namespace :__jidoka__
 
   @schema Zoi.struct(
             __MODULE__,
@@ -226,13 +227,23 @@ defmodule Jidoka.Context do
     end
   end
 
+  @doc "Projects caller data into the context map expected by Jido actions."
+  @spec to_action_context(t()) :: map()
+  def to_action_context(%__MODULE__{} = context) do
+    context
+    |> data()
+    |> Map.drop([@action_context_namespace, Atom.to_string(@action_context_namespace)])
+    |> Map.put(@action_context_namespace, %{context: context})
+  end
+
   @doc "Fetches an application context value by atom or string key without creating atoms."
-  @spec fetch(t(), atom() | String.t()) :: {:ok, term()} | :error
+  @spec fetch(t() | map(), atom() | String.t()) :: {:ok, term()} | :error
   def fetch(%__MODULE__{data: data}, key), do: fetch_any(data, key)
+  def fetch(context, key) when is_map(context), do: fetch_any(context, key)
 
   @doc "Returns an application context value by atom or string key without creating atoms."
-  @spec get(t(), atom() | String.t(), term()) :: term()
-  def get(%__MODULE__{} = context, key, default \\ nil) do
+  @spec get(t() | map(), atom() | String.t(), term()) :: term()
+  def get(context, key, default \\ nil) when is_map(context) do
     case fetch(context, key) do
       {:ok, value} -> value
       :error -> default
@@ -248,12 +259,17 @@ defmodule Jidoka.Context do
   def runtime(%__MODULE__{runtime: runtime}), do: runtime
 
   @doc "Fetches a runtime-only value by atom or string key without creating atoms."
-  @spec fetch_runtime(t(), atom() | String.t()) :: {:ok, term()} | :error
+  @spec fetch_runtime(t() | map(), atom() | String.t()) :: {:ok, term()} | :error
   def fetch_runtime(%__MODULE__{runtime: runtime}, key), do: fetch_any(runtime, key)
 
+  def fetch_runtime(%{@action_context_namespace => %{context: %__MODULE__{} = context}}, key),
+    do: fetch_runtime(context, key)
+
+  def fetch_runtime(context, _key) when is_map(context), do: :error
+
   @doc "Returns a runtime-only value by atom or string key without creating atoms."
-  @spec get_runtime(t(), atom() | String.t(), term()) :: term()
-  def get_runtime(%__MODULE__{} = context, key, default \\ nil) do
+  @spec get_runtime(t() | map(), atom() | String.t(), term()) :: term()
+  def get_runtime(context, key, default \\ nil) when is_map(context) do
     case fetch_runtime(context, key) do
       {:ok, value} -> value
       :error -> default

--- a/lib/jidoka/runtime/jido_actions.ex
+++ b/lib/jidoka/runtime/jido_actions.ex
@@ -55,7 +55,7 @@ defmodule Jidoka.Runtime.JidoActions do
       %Effect.Intent{kind: :operation, payload: payload}, %Effect.Journal{}, %Jidoka.Context{} = context ->
         with {:ok, request} <- Effect.OperationRequest.from_input(payload),
              {:ok, tool} <- fetch_tool(tools, request.name) do
-          call_tool(tool, request.arguments, context)
+          invoke_tool(tool, request.arguments, context)
         end
 
       %Effect.Intent{kind: kind}, _journal, %Jidoka.Context{} ->
@@ -70,12 +70,18 @@ defmodule Jidoka.Runtime.JidoActions do
     end
   end
 
-  defp call_tool(%{function: function}, arguments, context) when is_function(function, 2) do
-    case function.(arguments, context) do
+  @doc false
+  @spec invoke_tool(map(), map(), Jidoka.Context.t()) :: {:ok, term()} | {:error, term()}
+  def invoke_tool(%{function: function}, arguments, %Jidoka.Context{} = context)
+      when is_function(function, 2) and is_map(arguments) do
+    case function.(arguments, Jidoka.Context.to_action_context(context)) do
       {:ok, encoded} -> {:ok, decode_tool_payload(encoded)}
       {:error, encoded} -> {:error, decode_tool_payload(encoded)}
+      other -> {:error, {:invalid_action_result, other}}
     end
   end
+
+  def invoke_tool(_tool, _arguments, _context), do: {:error, :invalid_action_tool}
 
   defp decode_tool_payload(encoded) when is_binary(encoded) do
     case Jason.decode(encoded) do

--- a/lib/jidoka/workflow/lua/plan.ex
+++ b/lib/jidoka/workflow/lua/plan.ex
@@ -4,10 +4,11 @@ defmodule Jidoka.Workflow.Lua.Plan do
   require Runic
   import Runic, only: [context: 1]
 
+  alias Jidoka.Context
+  alias Jidoka.Runtime.JidoActions
   alias Jidoka.Workflow.Lua.CallTrace
   alias Jidoka.Workflow.Lua.Plan.{Ref, Spec}
   alias Jidoka.Workflow.Lua.Policy
-  alias Jidoka.Context
   alias Runic.Workflow
 
   @type t :: Spec.t()
@@ -369,23 +370,9 @@ defmodule Jidoka.Workflow.Lua.Plan do
   end
 
   defp run_action(action, arguments, context) do
-    tool = action.to_tool()
-
-    case tool.function.(arguments, context) do
-      {:ok, encoded} -> {:ok, decode_tool_payload(encoded)}
-      {:error, encoded} -> {:error, decode_tool_payload(encoded)}
-      other -> {:error, {:invalid_action_result, other}}
-    end
+    action.to_tool()
+    |> JidoActions.invoke_tool(arguments, context)
   end
-
-  defp decode_tool_payload(encoded) when is_binary(encoded) do
-    case Jason.decode(encoded) do
-      {:ok, decoded} -> decoded
-      {:error, _reason} -> encoded
-    end
-  end
-
-  defp decode_tool_payload(value), do: value
 
   defp format_reason(reason) when is_binary(reason), do: reason
   defp format_reason(reason), do: inspect(reason)

--- a/lib/jidoka/workflow/runtime/step_runner.ex
+++ b/lib/jidoka/workflow/runtime/step_runner.ex
@@ -1,6 +1,7 @@
 defmodule Jidoka.Workflow.Runtime.StepRunner do
   @moduledoc false
 
+  alias Jidoka.Runtime.JidoActions
   alias Jidoka.Workflow.Runtime.{Retry, Value}
   alias Jidoka.Workflow.Step
 
@@ -42,7 +43,7 @@ defmodule Jidoka.Workflow.Runtime.StepRunner do
   def execute_step(%Step{kind: :action} = step, state) do
     with {:ok, params} <- resolve_map(step.input, state, :action_input),
          {:ok, tool} <- action_tool(step.target) do
-      Retry.call(step, fn -> call_tool(tool, params, state.context) end)
+      Retry.call(step, fn -> JidoActions.invoke_tool(tool, params, state.context) end)
     end
   end
 
@@ -190,7 +191,7 @@ defmodule Jidoka.Workflow.Runtime.StepRunner do
 
   defp execute_map_target(%Step{target_kind: :action} = step, params, context) do
     with {:ok, tool} <- action_tool(step.target) do
-      Retry.call(step, fn -> call_tool(tool, params, context) end)
+      Retry.call(step, fn -> JidoActions.invoke_tool(tool, params, context) end)
     end
   end
 
@@ -222,25 +223,6 @@ defmodule Jidoka.Workflow.Runtime.StepRunner do
   end
 
   defp action_tool(action), do: {:error, {:invalid_action_module, action}}
-
-  defp call_tool(%{function: function}, arguments, context) when is_function(function, 2) do
-    case function.(arguments, context) do
-      {:ok, encoded} -> {:ok, decode_tool_payload(encoded)}
-      {:error, encoded} -> {:error, decode_tool_payload(encoded)}
-      other -> {:error, {:invalid_action_result, other}}
-    end
-  end
-
-  defp call_tool(_tool, _arguments, _context), do: {:error, :invalid_action_tool}
-
-  defp decode_tool_payload(encoded) when is_binary(encoded) do
-    case Jason.decode(encoded) do
-      {:ok, decoded} -> decoded
-      {:error, _reason} -> encoded
-    end
-  end
-
-  defp decode_tool_payload(value), do: value
 
   defp ensure_prompt(prompt) when is_binary(prompt), do: {:ok, prompt}
   defp ensure_prompt(prompt), do: {:error, {:expected_prompt, prompt}}

--- a/showcase/lib/jidoka_showcase/kitchen_sink_agent/actions/show_context.ex
+++ b/showcase/lib/jidoka_showcase/kitchen_sink_agent/actions/show_context.ex
@@ -8,7 +8,7 @@ defmodule JidokaShowcase.KitchenSinkAgent.Actions.ShowContext do
 
   @impl true
   def run(_params, context) do
-    public_context = Jidoka.Context.data(context)
+    public_context = Map.drop(context, [:__jidoka__, "__jidoka__", :__struct__])
 
     {:ok,
      %{

--- a/showcase/test/kitchen_sink_agent_test.exs
+++ b/showcase/test/kitchen_sink_agent_test.exs
@@ -65,28 +65,32 @@ defmodule JidokaShowcase.KitchenSinkAgentTest do
            end)
 
     assert Enum.any?(spec.controls.operations, fn control ->
-             control.control == AllowSpecialistHandoff and control.match[:name] == "refund_specialist"
+             control.control == AllowSpecialistHandoff and
+               control.match[:name] == "refund_specialist"
            end)
   end
 
   test "show context action returns public context keys only" do
+    context =
+      Jidoka.Context.from_data!(
+        %{
+          actor: %{id: "dev-1", role: "developer"},
+          channel: "kitchen_sink",
+          example: "kitchen_sink_agent",
+          session_id: "session_123",
+          surface: "test",
+          tenant: "demo"
+        },
+        runtime: %{
+          agent_module: Agent,
+          memory_store: :private
+        }
+      )
+
     assert {:ok, result} =
              ShowContext.run(
                %{},
-               Jidoka.Context.from_data!(
-                 %{
-                   actor: %{id: "dev-1", role: "developer"},
-                   channel: "kitchen_sink",
-                   example: "kitchen_sink_agent",
-                   session_id: "session_123",
-                   surface: "test",
-                   tenant: "demo"
-                 },
-                 runtime: %{
-                   agent_module: Agent,
-                   memory_store: :private
-                 }
-               )
+               Jidoka.Context.to_action_context(context)
              )
 
     assert result["actor"] == %{id: "dev-1", role: "developer"}
@@ -95,6 +99,7 @@ defmodule JidokaShowcase.KitchenSinkAgentTest do
     assert result["session_id"] == "session_123"
     assert result["surface"] == "test"
     assert result["tenant"] == "demo"
+    refute "__jidoka__" in result["keys"]
     assert "agent_module" not in result["keys"]
     assert "memory_store" not in result["keys"]
   end

--- a/test/examples/proof_model_test.exs
+++ b/test/examples/proof_model_test.exs
@@ -275,6 +275,8 @@ defmodule JidokaExamples.ProofModelTest do
              :showcase_test
            ]
 
+    assert hd(focused.gates).timeout_ms == 240_000
+
     assert {:ok, full} = Planner.plan(examples, [], File.cwd!())
     assert full.mode == :all
     assert Enum.any?(full.gates, &(&1.id == :documentation))

--- a/test/examples/proof_model_test.exs
+++ b/test/examples/proof_model_test.exs
@@ -276,6 +276,7 @@ defmodule JidokaExamples.ProofModelTest do
            ]
 
     assert hd(focused.gates).timeout_ms == 240_000
+    assert Enum.find(focused.gates, &(&1.id == :showcase_compile)).timeout_ms == 240_000
 
     assert {:ok, full} = Planner.plan(examples, [], File.cwd!())
     assert full.mode == :all

--- a/test/integration/ash_jido_context_integration_test.exs
+++ b/test/integration/ash_jido_context_integration_test.exs
@@ -1,0 +1,90 @@
+defmodule Jidoka.AshJidoContextIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.Effect
+  alias Jidoka.Turn
+
+  import Jidoka.TestSupport, only: [count_results: 2]
+
+  defmodule ContextProbeResource do
+    @moduledoc false
+
+    use Ash.Resource,
+      domain: Jidoka.AshJidoContextIntegrationTest.TestDomain,
+      extensions: [AshJido]
+
+    actions do
+      action :context_probe, :map do
+        run(fn _input, context ->
+          {:ok, %{actor: context.actor, tenant: context.tenant}}
+        end)
+      end
+    end
+
+    jido do
+      action(:context_probe, name: "ash_context_probe")
+    end
+  end
+
+  defmodule TestDomain do
+    @moduledoc false
+
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      resource(ContextProbeResource)
+    end
+  end
+
+  defmodule ContextAgent do
+    @moduledoc false
+
+    use Jidoka.Agent
+
+    agent :ash_jido_context_agent do
+      model %{provider: :test, id: "model"}
+      instructions "Use the Ash context probe before answering."
+    end
+
+    tools do
+      ash_resource ContextProbeResource, actions: [:context_probe]
+    end
+  end
+
+  test "generated AshJido actions receive actor and tenant through a full turn" do
+    actor = %{id: "actor-1"}
+
+    llm = fn _intent, %Effect.Journal{} = journal, _context ->
+      case count_results(journal, :llm) do
+        0 ->
+          {:ok, %{type: :operation, name: "ash_context_probe", arguments: %{}}}
+
+        1 ->
+          assert journal.results
+                 |> Map.values()
+                 |> Enum.any?(&match?(%Effect.Result{kind: :operation}, &1))
+
+          {:ok, %{type: :final, content: "Ash context received."}}
+      end
+    end
+
+    request =
+      Turn.Request.new!(
+        input: "Inspect the current Ash actor and tenant.",
+        context: %{actor: actor, tenant: "tenant-1"}
+      )
+
+    assert {:ok, %Turn.Result{content: "Ash context received."} = result} =
+             ContextAgent.run_turn(request, llm: llm)
+
+    assert [
+             %Effect.OperationResult{
+               operation: "ash_context_probe",
+               output: %{
+                 "actor" => %{"id" => "actor-1"},
+                 "tenant" => "tenant-1"
+               }
+             }
+           ] = result.agent_state.operation_results
+  end
+end

--- a/test/jidoka/browser_test.exs
+++ b/test/jidoka/browser_test.exs
@@ -112,14 +112,35 @@ defmodule Jidoka.BrowserTest do
       )
 
     context = Jidoka.Context.from_data!(%{}, runtime: %{jidoka_spec: %{operations: [operation]}})
+    action_context = Jidoka.Context.to_action_context(context)
 
     assert :ok =
              Runtime.validate_allowlist("https://docs.example.com/guide", context, "read_page")
+
+    assert :ok =
+             Runtime.validate_allowlist("https://docs.example.com/guide", action_context, "read_page")
 
     assert :ok = Runtime.validate_allowlist("https://example.com", %{}, "read_page")
 
     assert {:error, %Jidoka.Error.ValidationError{details: %{reason: :browser_url_not_allowed}}} =
              Runtime.validate_allowlist("https://example.com", context, "read_page")
+
+    assert {:error, %Jidoka.Error.ValidationError{details: %{reason: :browser_url_not_allowed}}} =
+             Runtime.validate_allowlist("https://example.com", action_context, "read_page")
+
+    assert {:error, %Jidoka.Error.ValidationError{details: %{reason: :browser_url_not_allowed}}} =
+             Runtime.validate_allowlist(:not_a_url, action_context, "read_page")
+
+    missing_operation_context =
+      Jidoka.Context.from_data!(%{}, runtime: %{jidoka_spec: %{operations: []}})
+      |> Jidoka.Context.to_action_context()
+
+    assert :ok =
+             Runtime.validate_allowlist(
+               "https://example.com",
+               missing_operation_context,
+               "read_page"
+             )
   end
 
   test "browser allowlists reject prefix-confused hosts and enforce URL paths" do

--- a/test/jidoka/data_structs_test.exs
+++ b/test/jidoka/data_structs_test.exs
@@ -161,10 +161,46 @@ defmodule Jidoka.DataStructsTest do
     assert %Jidoka.Context{runtime: %{client: :trusted}} =
              Jidoka.Context.from_data!(trusted_context, runtime: %{client: :trusted})
 
+    assert %Jidoka.Context{data: %{}} = Jidoka.Context.from_data!(nil)
+    assert {:error, {:invalid_context_data, :invalid}} = Jidoka.Context.from_data(:invalid)
+
+    assert_raise ArgumentError, ~r/invalid context data/, fn ->
+      Jidoka.Context.from_data!(:invalid)
+    end
+
     assert %{tenant: "northwind"} =
              Jidoka.Context.from_data!(%{tenant: "northwind"}, runtime: %{client: :trusted})
              |> Jidoka.Context.sanitize()
              |> Jidoka.Context.data()
+  end
+
+  test "Jidoka.Context projects a spoof-safe Jido action context" do
+    context =
+      Jidoka.Context.from_data!(
+        %{
+          "__jidoka__" => :spoofed_string,
+          actor: "actor-1",
+          tenant: "tenant-1",
+          __jidoka__: :spoofed_atom
+        },
+        runtime: %{client: :trusted},
+        boundary: :operation,
+        operation: "lookup"
+      )
+
+    action_context = Jidoka.Context.to_action_context(context)
+
+    refute is_struct(action_context)
+    assert Map.get(action_context, :actor) == "actor-1"
+    assert action_context[:tenant] == "tenant-1"
+    assert Jidoka.Context.get(action_context, :actor) == "actor-1"
+    assert Jidoka.Context.get_runtime(action_context, :client) == :trusted
+    assert Jidoka.Context.fetch_runtime(%{}, :client) == :error
+    assert Jidoka.Context.get_runtime(%{}, :client, :missing) == :missing
+    assert action_context.__jidoka__.context == context
+    refute Map.has_key?(action_context, "__jidoka__")
+    refute Map.has_key?(action_context, :runtime)
+    refute Map.has_key?(action_context, :operation)
   end
 
   test "operation specs carry approval policy data" do

--- a/test/jidoka/data_structs_test.exs
+++ b/test/jidoka/data_structs_test.exs
@@ -18,6 +18,12 @@ defmodule Jidoka.DataStructsTest.Support.AmountPredicate do
   end
 end
 
+defmodule Jidoka.DataStructsTest.Support.CallerData do
+  @moduledoc false
+
+  defstruct [:actor, :tenant]
+end
+
 defmodule Jidoka.DataStructsTest do
   use ExUnit.Case, async: true
 
@@ -30,7 +36,7 @@ defmodule Jidoka.DataStructsTest do
   alias Jidoka.Review
   alias Jidoka.Runtime.AgentSnapshot
   alias Jidoka.Turn
-  alias Jidoka.DataStructsTest.Support.{AllowControl, AmountPredicate}
+  alias Jidoka.DataStructsTest.Support.{AllowControl, AmountPredicate, CallerData}
 
   test "agent state accepts nil, maps, and structs as input" do
     assert {:ok, %Agent.State{messages: [], operation_results: [], metadata: %{}}} =
@@ -201,6 +207,27 @@ defmodule Jidoka.DataStructsTest do
     refute Map.has_key?(action_context, "__jidoka__")
     refute Map.has_key?(action_context, :runtime)
     refute Map.has_key?(action_context, :operation)
+  end
+
+  test "Jidoka.Context removes struct identity from Jido action context data" do
+    %Jidoka.Context{} = context = Jidoka.Context.from_data!(%{})
+
+    context =
+      %Jidoka.Context{
+        context
+        | data: %CallerData{
+            actor: "actor-1",
+            tenant: "tenant-1"
+          }
+      }
+
+    action_context = Jidoka.Context.to_action_context(context)
+
+    refute is_struct(action_context)
+    refute Map.has_key?(action_context, :__struct__)
+    assert action_context.actor == "actor-1"
+    assert action_context.tenant == "tenant-1"
+    assert action_context.__jidoka__.context == context
   end
 
   test "operation specs carry approval policy data" do

--- a/test/jidoka/runtime/jido_actions_test.exs
+++ b/test/jidoka/runtime/jido_actions_test.exs
@@ -10,7 +10,15 @@ defmodule Jidoka.Runtime.JidoActionsTest.Support.EchoAction do
   @impl true
   def run(params, context) do
     value = Map.get(params, :value) || Map.get(params, "value")
-    {:ok, %{value: value, marker: Jidoka.Context.get(context, :marker)}}
+
+    {:ok,
+     %{
+       value: value,
+       marker: Map.get(context, :marker),
+       access_marker: context[:marker],
+       helper_marker: Jidoka.Context.get(context, :marker),
+       runtime_marker: Jidoka.Context.get_runtime(context, :runtime_marker)
+     }}
   end
 end
 
@@ -36,13 +44,32 @@ defmodule Jidoka.Runtime.JidoActionsTest do
 
   test "executes Jido action tools and decodes JSON payloads" do
     capability = Actions.operations([EchoAction])
-    ctx = Jidoka.Context.from_data!(marker: "unit")
+    ctx = Jidoka.Context.from_data!([marker: "unit"], runtime: %{runtime_marker: "trusted"})
 
     intent =
       Effect.Intent.new(:operation, %{name: "echo_value", arguments: %{"value" => "hello"}})
 
-    assert {:ok, %{"value" => "hello", "marker" => "unit"}} =
+    assert {:ok,
+            %{
+              "value" => "hello",
+              "marker" => "unit",
+              "access_marker" => "unit",
+              "helper_marker" => "unit",
+              "runtime_marker" => "trusted"
+            }} =
              capability.(intent, Effect.Journal.new!(), ctx)
+  end
+
+  test "normalizes invalid Jido action tool results" do
+    context = Jidoka.Context.from_data!(%{})
+    tool = %{function: fn _arguments, _context -> :invalid end}
+    raw_tool = %{function: fn _arguments, _context -> {:ok, %{raw: true}} end}
+
+    assert {:error, {:invalid_action_result, :invalid}} =
+             Actions.invoke_tool(tool, %{}, context)
+
+    assert {:ok, %{raw: true}} = Actions.invoke_tool(raw_tool, %{}, context)
+    assert {:error, :invalid_action_tool} = Actions.invoke_tool(%{}, %{}, context)
   end
 
   test "reports missing Jido action tools" do

--- a/test/jidoka/workflow/lua_test.exs
+++ b/test/jidoka/workflow/lua_test.exs
@@ -103,6 +103,25 @@ defmodule Jidoka.Workflow.LuaTest do
     def run(_params, _context), do: {:ok, %{"mutated" => true}}
   end
 
+  defmodule ReadActionContext do
+    @moduledoc false
+
+    use Jidoka.Action,
+      name: "workflow_lua_read_action_context",
+      description: "Reads caller data from the Jido action context.",
+      schema: Zoi.object(%{})
+
+    @impl true
+    def run(_params, context) do
+      {:ok,
+       %{
+         actor: Map.get(context, :actor),
+         access_actor: context[:actor],
+         helper_actor: Jidoka.Context.get(context, :actor)
+       }}
+    end
+  end
+
   test "requires a catalog or entries" do
     assert {:error, :missing_lua_workflow_catalog} = Lua.execute("return {}")
   end
@@ -203,6 +222,26 @@ defmodule Jidoka.Workflow.LuaTest do
     assert result["call_count"] == 3
     assert result["result"]["workflow_id"] == "invoice_followup"
     assert result["result"]["output"]["note"] =~ "Ada Lovelace"
+  end
+
+  test "Lua workflow actions receive the projected Jido action context" do
+    script = """
+    return jidoka.workflow({
+      id = "context_projection",
+      steps = {
+        {id = "context", tool = "context.read", arguments = {}}
+      },
+      output = "context"
+    })
+    """
+
+    assert {:ok, result} = Lua.execute(script, catalog: catalog(), context: %{actor: "actor-1"})
+
+    assert result["result"]["output"] == %{
+             "actor" => "actor-1",
+             "access_actor" => "actor-1",
+             "helper_actor" => "actor-1"
+           }
   end
 
   test "requires the script to return the workflow result" do
@@ -332,6 +371,12 @@ defmodule Jidoka.Workflow.LuaTest do
       description: "Mutate",
       visibility: :hidden,
       read_only?: false
+    )
+    |> Catalog.register!(ReadActionContext,
+      id: "context.read",
+      description: "Read action context",
+      visibility: :hidden,
+      read_only?: true
     )
   end
 end

--- a/test/jidoka/workflow_dsl_test.exs
+++ b/test/jidoka/workflow_dsl_test.exs
@@ -42,6 +42,26 @@ defmodule Jidoka.WorkflowDslTest do
     def run(%{value: value}, _context), do: {:ok, %{value: value * 2}}
   end
 
+  defmodule InspectActionContext do
+    @moduledoc false
+
+    use Jidoka.Action,
+      name: "workflow_inspect_action_context",
+      description: "Inspects the Jido action context projection.",
+      schema: Zoi.object(%{})
+
+    @impl true
+    def run(_params, context) do
+      {:ok,
+       %{
+         actor: Map.get(context, :actor),
+         access_actor: context[:actor],
+         helper_actor: Jidoka.Context.get(context, :actor),
+         runtime_value: Jidoka.Context.get_runtime(context, :trusted)
+       }}
+    end
+  end
+
   defmodule Fns do
     @moduledoc false
 
@@ -302,6 +322,23 @@ defmodule Jidoka.WorkflowDslTest do
     end
 
     output from(:double)
+  end
+
+  defmodule ActionContextWorkflow do
+    @moduledoc false
+
+    use Jidoka.Workflow
+
+    workflow do
+      id(:action_context_workflow)
+      input Zoi.object(%{})
+    end
+
+    steps do
+      action(:inspect_context, InspectActionContext, input: %{})
+    end
+
+    output from(:inspect_context)
   end
 
   defmodule SlowWorkflow do
@@ -1058,6 +1095,19 @@ defmodule Jidoka.WorkflowDslTest do
     assert error.details.cause == {:retry_exhausted, 2, :still_failing}
   end
 
+  test "workflow actions receive the projected Jido action context" do
+    context =
+      Jidoka.Context.from_data!(%{actor: "actor-1"}, runtime: %{trusted: "runtime-value"})
+
+    assert {:ok,
+            %{
+              "actor" => "actor-1",
+              "access_actor" => "actor-1",
+              "helper_actor" => "actor-1",
+              "runtime_value" => "runtime-value"
+            }} = Workflow.run(ActionContextWorkflow, %{}, context: context)
+  end
+
   test "workflow total timeout still wins over retry backoff" do
     started_at = System.monotonic_time(:millisecond)
 
@@ -1069,7 +1119,13 @@ defmodule Jidoka.WorkflowDslTest do
   end
 
   test "workflow step runner exposes clear failure modes" do
-    state = %{input: %{}, context: %{}, steps: %{}, agent_opts: [], error: nil}
+    state = %{
+      input: %{},
+      context: Jidoka.Context.from_data!(%{}),
+      steps: %{},
+      agent_opts: [],
+      error: nil
+    }
 
     spec = Spec.new!(id: "step_runner_workflow", module: __MODULE__)
 

--- a/test/mix/tasks/jidoka_example_test.exs
+++ b/test/mix/tasks/jidoka_example_test.exs
@@ -1,0 +1,50 @@
+defmodule Mix.Tasks.Jidoka.ExampleTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    Mix.shell(Mix.Shell.Process)
+
+    on_exit(fn ->
+      Mix.shell(Mix.Shell.IO)
+    end)
+
+    :ok
+  end
+
+  test "prints help when no example is selected" do
+    run_task([])
+
+    assert_receive {:mix_shell, :info, [help]}
+    assert help =~ "mix jidoka.example --list"
+    assert help =~ "--json"
+  end
+
+  test "lists the example catalog as text and JSON" do
+    run_task(["--list"])
+
+    assert_receive {:mix_shell, :info, ["Available Jidoka examples:\n"]}
+    assert_receive {:mix_shell, :info, [example]}
+    assert example =~ "support_agent"
+
+    run_task(["--list", "--json"])
+
+    assert_receive {:mix_shell, :info, [encoded]}
+    assert [%{"name" => "support_agent"} = support_agent] = Jason.decode!(encoded)
+    assert is_list(support_agent["capabilities"])
+  end
+
+  test "rejects invalid options and extra example names" do
+    assert_raise Mix.Error, ~r/Unknown jidoka.example options/, fn ->
+      run_task(["--unknown"])
+    end
+
+    assert_raise Mix.Error, ~r/Expected one example name/, fn ->
+      run_task(["support_agent", "another_agent"])
+    end
+  end
+
+  defp run_task(args) do
+    Mix.Task.reenable("jidoka.example")
+    assert :ok == Mix.Task.run("jidoka.example", args)
+  end
+end


### PR DESCRIPTION
## Summary\n\n- project caller context data into the plain map required by the Jido Action contract\n- preserve trusted Jidoka runtime context under a spoof-safe  namespace\n- remove struct identity and reserved-key spoofing from projected action contexts\n- use one action invoker for standard operations, DSL workflows, and Lua workflows\n- keep browser allowlist checks working with projected action contexts\n- make the showcase action and test use the projected context contract\n- update the AshJido guide and its current DSL example\n- keep the example proof system compatible with Elixir 1.18 through 1.20\n- give cold root and showcase compilation enough time in CI\n- add coverage for the example Mix task entry points\n\n## Root cause\n\nJidoka passed its internal  struct directly to . Caller data such as  and  remained nested under , so actions that used  or  could not read it.\n\nThe existing CI failures were separate defects on : the proof formatter accessed an ExUnit field that is not available before Elixir 1.20, older coverage engines exposed that the suite had almost no margin above 80%, and cold root and showcase builds exceeded their original time budgets.\n\n## Impact\n\nGenerated AshJido actions now receive actor and tenant as top-level context keys. Ordinary Jido actions get the same context contract in agent turns, DSL workflows, and Lua workflows. Runtime capabilities and operation metadata are not flattened into the public map.\n\n## Validation\n\n- \n- \n- Cover compiling modules ...
Running ExUnit with seed: 765135, max_cases: 20
Excluding tags: [:live, :parity]

.......................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 10.6 seconds (4.3s async, 6.2s sync)

Result: 439 passed, 8 excluded

Exporting cover results ...

Run "mix test.coverage" once all exports complete — 439 passed, 8 excluded\n- Importing cover results: cover/cov.coverdata

| Percentage | Module                                     |
|------------|--------------------------------------------|
|     24.00% | Mix.Tasks.Jidoka.Examples.Check            |
|     25.22% | Jidoka.Runtime.ReqLLM                      |
|     40.26% | Jidoka.Memory.Store.JidoMemory             |
|     45.00% | Jidoka.ApprovalPredicate                   |
|     54.55% | Jidoka.Workflow.RetryPolicy                |
|     55.56% | Jidoka.Import.AgentDocument                |
|     55.81% | Jidoka.Review.Approval                     |
|     56.25% | Jidoka.Controls.MaxInputLength             |
|     58.70% | Jidoka.Import.Normalize                    |
|     60.00% | Jidoka.Agent.ServerOptions                 |
|     60.00% | Jidoka.Controls.RequireContext             |
|     61.11% | Jidoka.Harness.Session                     |
|     61.11% | Jidoka.Runtime.OperationBatch              |
|     61.29% | Jidoka.Agent.ToolSources.Common            |
|     61.64% | Jidoka.AgentView                           |
|     62.50% | Jidoka.Error.Internal.UnknownError         |
|     63.10% | Jidoka.Workflow.Lua.Plan.Ref               |
|     63.64% | Jidoka.Controls.RequireApproval            |
|     64.39% | Jidoka.Operation.Source.Handoff            |
|     65.00% | Jidoka.Agent.ToolSources.Skill             |
|     66.00% | Jidoka.Workflow.Lua.Plan                   |
|     66.67% | Jidoka.Debug.RequestSummary                |
|     66.67% | Jidoka.Inspection.Preflight                |
|     66.67% | Jidoka.Memory.WriteResult                  |
|     66.67% | Jidoka.Projection.Metadata                 |
|     66.67% | Jidoka.Runtime.Capabilities                |
|     66.67% | Jidoka.Runtime.Context                     |
|     66.67% | Jidoka.Runtime.Controls.OperationContext   |
|     66.67% | Jidoka.Session                             |
|     66.67% | Mix.Tasks.Jidoka.Example                   |
|     67.01% | Jidoka.Operation.Source.Subagent           |
|     68.18% | Jidoka.Import.Registry                     |
|     68.75% | Jidoka.Agent.Spec.Memory                   |
|     70.00% | Jidoka.Trace.Sink                          |
|     70.83% | Jidoka.Facade.AgentServer                  |
|     71.43% | Jidoka.Workflow.Lua.Policy                 |
|     71.79% | Jidoka.Import.Controls                     |
|     71.79% | Jidoka.Operation.Source.MCP.Transport      |
|     72.22% | Jidoka.Projection.Workflow                 |
|     72.65% | Jidoka.Browser.Runtime                     |
|     72.97% | Jidoka.Stream                              |
|     75.00% | Jidoka.Browser.Tools.SearchWeb             |
|     75.00% | Jidoka.Debug.ReplayDiagnostics             |
|     75.00% | Jidoka.Error.ConfigError                   |
|     75.00% | Jidoka.Eval.Run                            |
|     75.00% | Jidoka.ParityCase                          |
|     75.00% | Jidoka.Workflow.Lua.Plan.Spec              |
|     75.58% | Jidoka.Import                              |
|     75.93% | Jidoka.Operation.Source.Catalog.Normalize  |
|     75.96% | Jidoka.Export                              |
|     76.19% | Jidoka.Runtime.AgentServerState            |
|     76.74% | Jidoka.Harness.Replay                      |
|     76.74% | Jidoka.Runtime.Controls                    |
|     76.92% | Jidoka.Review.Response                     |
|     77.08% | Jidoka.Runtime.Actions.RunTurn             |
|     77.97% | Jidoka.Trace                               |
|     78.22% | Jidoka.Runtime.AgentSnapshot               |
|     78.57% | Jidoka.Browser.Tools.ReadPage              |
|     78.57% | Jidoka.Review.Interrupt                    |
|     78.95% | Jidoka.Control                             |
|     78.95% | Jidoka.Workflow.Definition.Validation      |
|     79.07% | Jidoka.Eval                                |
|     79.17% | Jidoka                                     |
|     79.41% | Jidoka.Projection                          |
|     79.78% | Jidoka.Agent.Spec.Controls.Operation       |
|     80.00% | Jidoka.Effect.Journal                      |
|     80.00% | Jidoka.Review.Request                      |
|     80.00% | Jidoka.Runtime.CapabilityInvoker           |
|     80.33% | Jidoka.Workflow.Lua                        |
|     80.65% | Jidoka.Agent.Spec.Result                   |
|     81.58% | Jidoka.Import.Decoder                      |
|     81.63% | Jidoka.Workflow.Lua.Plan.Spec.Graph        |
|     81.69% | Jidoka.Agent.Spec.Controls                 |
|     81.97% | Jidoka.Skill                               |
|     82.35% | Jidoka.Workflow.Runtime.Value              |
|     82.50% | Jidoka.Chat.Request                        |
|     82.50% | Jidoka.Effect.LLMDecision                  |
|     82.76% | Jidoka.Operation.Source.MCP.Tools          |
|     82.81% | Jidoka.Projection.AgentSpec                |
|     82.93% | Jidoka.Config                              |
|     83.33% | Jidoka.Import.Tools                        |
|     83.33% | Jidoka.Operation.Source.MCP                |
|     83.33% | Jidoka.Runtime.Signals                     |
|     83.45% | Jidoka.Runtime.ReqLLM.Decision             |
|     83.50% | Jidoka.Runtime.EffectInterpreter           |
|     83.59% | Jidoka.Debug                               |
|     84.21% | Jidoka.Error.Normalize.Helpers             |
|     84.21% | Jidoka.Workflow.Runtime.Retry              |
|     84.62% | Jidoka.Effect.OperationResult              |
|     84.62% | Jidoka.Turn.Transition                     |
|     85.39% | Jidoka.Turn.State                          |
|     85.71% | Jidoka.Agent.Message                       |
|     85.71% | Jidoka.Eval.Case                           |
|     85.71% | Jidoka.Handoff                             |
|     85.71% | Jidoka.Handoff.OwnerStore.InMemory         |
|     85.71% | Jidoka.Memory.Entry                        |
|     85.71% | Jidoka.Turn.Cursor                         |
|     85.71% | Jidoka.Workflow.Definition.Targets         |
|     85.83% | Jidoka.Agent                               |
|     86.24% | Jidoka.Harness                             |
|     86.49% | Jidoka.Review.Policy                       |
|     86.92% | Jidoka.Workflow.Runtime                    |
|     86.96% | Jidoka.Event                               |
|     86.96% | Jidoka.Harness.Store.InMemory              |
|     87.25% | Jidoka.Workflow.Runtime.StepRunner         |
|     87.50% | Jidoka.Browser.Tools.SnapshotUrl           |
|     87.50% | Jidoka.Memory.Store                        |
|     87.50% | Jidoka.Projection.Value                    |
|     87.50% | Jidoka.Schema                              |
|     87.50% | Jidoka.Trace.Policy                        |
|     87.80% | Jidoka.Context                             |
|     88.00% | Jidoka.Memory.Store.InMemory               |
|     88.41% | Jidoka.Inspection                          |
|     88.46% | Jidoka.Debug.Diagnostics                   |
|     88.68% | Jidoka.AgentView.Events                    |
|     88.89% | Jidoka.Agent.Spec.Controls.Input           |
|     88.89% | Jidoka.Agent.Spec.Controls.Output          |
|     88.89% | Jidoka.Agent.Spec.Operation                |
|     88.89% | Jidoka.Effect.Intent                       |
|     88.89% | Jidoka.Effect.OperationRequest             |
|     88.89% | Jidoka.Operation.Source.Workflow           |
|     88.89% | Jidoka.Trace.Sink.InMemory                 |
|     89.06% | Jidoka.Error.Format                        |
|     89.16% | Jidoka.Agent.ToolSources                   |
|     89.29% | Jidoka.Memory.Runtime                      |
|     89.47% | Jidoka.Workflow.Ref                        |
|     89.66% | Jidoka.Operation.Source                    |
|     89.74% | Jidoka.Workflow                            |
|     90.00% | Jidoka.Agent.ToolSources.AshResource       |
|     90.16% | Jidoka.Runtime.Review                      |
|     90.32% | Jidoka.Operation.Source.Local              |
|     90.91% | Jidoka.Error.Normalize.Runtime             |
|     91.04% | Jidoka.Runtime.Controls.Operation          |
|     91.40% | Jidoka.Operation.Source.Catalog            |
|     91.43% | Jidoka.Usage                               |
|     91.67% | Jidoka.Runtime.Spine.Steps                 |
|     92.00% | Jidoka.Turn.Result                         |
|     92.21% | Jidoka.Agent.Spec                          |
|     92.31% | Jidoka.Turn.Plan                           |
|     93.10% | Jidoka.Turn.Request                        |
|     94.12% | Jidoka.Agent.ToolSources.Browser           |
|     94.12% | Jidoka.Agent.ToolSources.Handoff           |
|     94.12% | Jidoka.Turn.State.OperationPlanner         |
|     94.74% | Jidoka.Agent.ToolSources.Subagent          |
|     95.00% | Jidoka.Harness.Store                       |
|     95.16% | Jidoka.Runtime.TurnRunner                  |
|     95.45% | Jidoka.Workflow.Definition                 |
|     96.00% | Jidoka.Agent.ToolSources.Workflow          |
|     96.00% | Jidoka.Workflow.Definition.Refs            |
|     96.15% | Jidoka.Agent.ToolSources.Catalog           |
|     96.59% | Jidoka.Workflow.Definition.Steps           |
|     96.67% | Jidoka.Agent.ToolSources.MCP               |
|     97.14% | Jidoka.Error.Normalize.Basic               |
|     97.14% | Jidoka.Workflow.Graph                      |
|    100.00% | Enumerable.Jidoka.Stream                   |
|    100.00% | Jidoka.Action                              |
|    100.00% | Jidoka.Agent.ControlCompiler               |
|    100.00% | Jidoka.Agent.SparkDsl                      |
|    100.00% | Jidoka.Agent.Spec.Generation               |
|    100.00% | Jidoka.Agent.State                         |
|    100.00% | Jidoka.Agent.ToolSources.Action            |
|    100.00% | Jidoka.Application                         |
|    100.00% | Jidoka.Browser                             |
|    100.00% | Jidoka.Effect.Result                       |
|    100.00% | Jidoka.Error                               |
|    100.00% | Jidoka.Error.Config                        |
|    100.00% | Jidoka.Error.Execution                     |
|    100.00% | Jidoka.Error.ExecutionError                |
|    100.00% | Jidoka.Error.Internal                      |
|    100.00% | Jidoka.Error.Invalid                       |
|    100.00% | Jidoka.Error.Normalize                     |
|    100.00% | Jidoka.Error.ValidationError               |
|    100.00% | Jidoka.Handoff.OwnerStore                  |
|    100.00% | Jidoka.Id                                  |
|    100.00% | Jidoka.Jido                                |
|    100.00% | Jidoka.Memory                              |
|    100.00% | Jidoka.Memory.RecallRequest                |
|    100.00% | Jidoka.Memory.RecallResult                 |
|    100.00% | Jidoka.Memory.WriteRequest                 |
|    100.00% | Jidoka.Operation.Source.Catalog.Parameters |
|    100.00% | Jidoka.Review                              |
|    100.00% | Jidoka.Runtime.Controls.Decision           |
|    100.00% | Jidoka.Runtime.EffectTrace                 |
|    100.00% | Jidoka.Runtime.JidoActions                 |
|    100.00% | Jidoka.Runtime.LocalOperations             |
|    100.00% | Jidoka.Runtime.Spine.Compiler              |
|    100.00% | Jidoka.Workflow.Codegen                    |
|    100.00% | Jidoka.Workflow.Definition.Error           |
|    100.00% | Jidoka.Workflow.Definition.Graph           |
|    100.00% | Jidoka.Workflow.Lua.CallTrace              |
|    100.00% | Jidoka.Workflow.Lua.Plan.Spec.Helpers      |
|    100.00% | Jidoka.Workflow.ParametersSchema           |
|    100.00% | Jidoka.Workflow.SparkDsl                   |
|    100.00% | Jidoka.Workflow.Spec                       |
|    100.00% | Jidoka.Workflow.Step                       |
|------------|--------------------------------------------|
|     80.45% | Total                                      |

Generated HTML coverage results in "cover" directory — 80.45%\n- Checking 296 source files (this might take a while) ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.7 seconds (0.06s to load, 0.6s running 57 checks on 296 files)
4350 mods/funs, found no issues.

Showing priority issues: ↑ ↗ →  (use `mix credo explain` to explain issues, `mix credo --help` for options).
Finding suitable PLTs
Checking PLT...
[:abnf_parsec, :anubis_mcp, :ash, :ash_jido, :asn1, :compiler, :crontab, :crux, :crypto, :decimal, :dotenvy, :ecto, :eex, :elixir, :ets, :extractous_ex, :finch, :floki, :flow, :fsmx, :fuse, :gen_stage, :hpax, :html2markdown, :idna, :inets, :iterex, :jason, :jido, :jido_action, :jido_ai, :jido_browser, :jido_mcp, :jido_signal, :jidoka, :jsv, :kernel, :llm_db, :logger, :lua, :mime, :mint, :mix, :mnesia, :multigraph, :nimble_options, :nimble_parsec, :nimble_pool, :peri, :poolboy, :public_key, :reactor, :req, :req_llm, :runic, :rustler, :rustler_precompiled, :sasl, :server_sent_events, :sourceror, :spark, :splode, :ssl, :stdlib, :stream_data, :telemetry, :telemetry_metrics, :texture, :time_zone_info, :uniq, :websockex, :yamerl, :yaml_elixir, :ymlr, :zoi]
PLT is up to date!
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: ~c"/Users/mhostetler/Source/Jido/jidoka/_build/dev/dialyxir_erlang-29.0.2_elixir-1.20.2_deps-dev.plt",
  files: [~c"/Users/mhostetler/Source/Jido/jidoka/_build/dev/lib/jidoka/ebin/Elixir.Jidoka.Jido.beam",
   ~c"/Users/mhostetler/Source/Jido/jidoka/_build/dev/lib/jidoka/ebin/Elixir.Jidoka.Export.beam",
   ~c"/Users/mhostetler/Source/Jido/jidoka/_build/dev/lib/jidoka/ebin/Elixir.Jidoka.Workflow.Dsl.Helpers.beam",
   ~c"/Users/mhostetler/Source/Jido/jidoka/_build/dev/lib/jidoka/ebin/Elixir.Jidoka.Agent.Dsl.Tools.Skill.beam",
   ~c"/Users/mhostetler/Source/Jido/jidoka/_build/dev/lib/jidoka/ebin/Elixir.Jidoka.Runtime.Controls.beam",
   ...],
  ...
]
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m6.22s
done (passed successfully)
Doctor file found. Loading configuration.
---------------------------------------------
Summary:

Passed Modules: 127
Failed Modules: 0
Total Doc Coverage: 98.4%
Total Moduledoc Coverage: 100.0%
Total Spec Coverage: 98.1%

Doctor validation has passed!\n- Jidoka example checks
Selected: support_agent
PASS  catalog (0 ms)
PASS  surface_contracts (0 ms)
PASS  root_compile (511 ms)
PASS  support_agent_exunit (1942 ms)
PASS  support_agent_livebook (2405 ms)
PASS  guide_contracts_and_runtime_livebook (1964 ms)
PASS  guide_controls_sessions_and_human_review_livebook (2019 ms)
PASS  guide_import_eval_and_trace_livebook (1682 ms)
PASS  guide_workflows_livebook (1613 ms)
PASS  showcase_compile (1417 ms)
PASS  showcase_test (2463 ms)
PASS  documentation (2201 ms)
PASS  proof_results (0 ms)
PASS  proof_document (0 ms)
Verified in this run: human_review, operation_control, snapshot_resume, tool_calling, tool_observation — all proof gates passed, including 52 showcase tests\n- formatter compilation on Elixir 1.18 / OTP 28 and Elixir 1.19 / OTP 28\n- Building jidoka 0.8.0-beta.1
  Dependencies:
    ash_jido ~> 1.0 (app: ash_jido)
    jido ~> 2.3 (app: jido)
    jido_action ~> 2.3 (app: jido_action)
    jido_ai ~> 2.2 (app: jido_ai)
    jido_browser ~> 2.1 (app: jido_browser)
    jido_mcp ~> 1.0 (app: jido_mcp)
    jason ~> 1.4 (app: jason)
    lua ~> 1.0.0-rc.0 (app: lua)
    req_llm ~> 1.12 (app: req_llm)
    runic ~> 0.1.0-alpha.7 (app: runic)
    splode ~> 0.3.0 (app: splode)
    spark ~> 2.6 (app: spark)
    yaml_elixir ~> 2.12 (app: yaml_elixir)
    ymlr ~> 5.1.6 (app: ymlr)
    zoi ~> 0.18 (app: zoi)
  App: jidoka
  Name: jidoka
  Files:
    lib
    lib/jidoka
    lib/jidoka/operation
    lib/jidoka/operation/source
    lib/jidoka/operation/source/local.ex
    lib/jidoka/operation/source/handoff.ex
    lib/jidoka/operation/source/catalog.ex
    lib/jidoka/operation/source/catalog
    lib/jidoka/operation/source/catalog/normalize.ex
    lib/jidoka/operation/source/catalog/parameters.ex
    lib/jidoka/operation/source/subagent.ex
    lib/jidoka/operation/source/mcp
    lib/jidoka/operation/source/mcp/tools.ex
    lib/jidoka/operation/source/mcp/transport.ex
    lib/jidoka/operation/source/workflow.ex
    lib/jidoka/operation/source/mcp.ex
    lib/jidoka/operation/source.ex
    lib/jidoka/handoff.ex
    lib/jidoka/approval_predicate.ex
    lib/jidoka/control.ex
    lib/jidoka/trace
    lib/jidoka/trace/policy.ex
    lib/jidoka/trace/sink
    lib/jidoka/trace/sink/in_memory.ex
    lib/jidoka/trace/sink.ex
    lib/jidoka/session.ex
    lib/jidoka/kino.ex
    lib/jidoka/memory
    lib/jidoka/memory/recall_result.ex
    lib/jidoka/memory/runtime.ex
    lib/jidoka/memory/store.ex
    lib/jidoka/memory/recall_request.ex
    lib/jidoka/memory/write_request.ex
    lib/jidoka/memory/write_result.ex
    lib/jidoka/memory/entry.ex
    lib/jidoka/memory/store
    lib/jidoka/memory/store/in_memory.ex
    lib/jidoka/memory/store/jido_memory.ex
    lib/jidoka/action.ex
    lib/jidoka/review.ex
    lib/jidoka/chat
    lib/jidoka/chat/request.ex
    lib/jidoka/stream.ex
    lib/jidoka/agent_view.ex
    lib/jidoka/agent_view
    lib/jidoka/agent_view/events.ex
    lib/jidoka/export.ex
    lib/jidoka/import.ex
    lib/jidoka/handoff
    lib/jidoka/handoff/owner_store
    lib/jidoka/handoff/owner_store/in_memory.ex
    lib/jidoka/handoff/owner_store.ex
    lib/jidoka/skill.ex
    lib/jidoka/event.ex
    lib/jidoka/harness.ex
    lib/jidoka/trace.ex
    lib/jidoka/runtime
    lib/jidoka/runtime/review.ex
    lib/jidoka/runtime/spine
    lib/jidoka/runtime/spine/steps.ex
    lib/jidoka/runtime/spine/compiler.ex
    lib/jidoka/runtime/effect_trace.ex
    lib/jidoka/runtime/req_llm
    lib/jidoka/runtime/req_llm/decision.ex
    lib/jidoka/runtime/operation_batch.ex
    lib/jidoka/runtime/jido_actions.ex
    lib/jidoka/runtime/controls.ex
    lib/jidoka/runtime/signals.ex
    lib/jidoka/runtime/capability_invoker.ex
    lib/jidoka/runtime/controls
    lib/jidoka/runtime/controls/operation.ex
    lib/jidoka/runtime/controls/decision.ex
    lib/jidoka/runtime/controls/operation_context.ex
    lib/jidoka/runtime/effect_interpreter.ex
    lib/jidoka/runtime/req_llm.ex
    lib/jidoka/runtime/actions
    lib/jidoka/runtime/actions/run_turn.ex
    lib/jidoka/runtime/turn_runner.ex
    lib/jidoka/runtime/agent_server_state.ex
    lib/jidoka/runtime/local_operations.ex
    lib/jidoka/runtime/context.ex
    lib/jidoka/runtime/capabilities.ex
    lib/jidoka/runtime/agent_snapshot.ex
    lib/jidoka/config.ex
    lib/jidoka/facade
    lib/jidoka/facade/agent_server.ex
    lib/jidoka/effect
    lib/jidoka/effect/operation_request.ex
    lib/jidoka/effect/intent.ex
    lib/jidoka/effect/operation_result.ex
    lib/jidoka/effect/journal.ex
    lib/jidoka/effect/result.ex
    lib/jidoka/effect/llm_decision.ex
    lib/jidoka/error.ex
    lib/jidoka/id.ex
    lib/jidoka/agent
    lib/jidoka/agent/spec.ex
    lib/jidoka/agent/tool_sources.ex
    lib/jidoka/agent/message.ex
    lib/jidoka/agent/server_options.ex
    lib/jidoka/agent/spark_dsl.ex
    lib/jidoka/agent/dsl.ex
    lib/jidoka/agent/spec
    lib/jidoka/agent/spec/operation.ex
    lib/jidoka/agent/spec/controls.ex
    lib/jidoka/agent/spec/generation.ex
    lib/jidoka/agent/spec/memory.ex
    lib/jidoka/agent/spec/controls
    lib/jidoka/agent/spec/controls/operation.ex
    lib/jidoka/agent/spec/controls/output.ex
    lib/jidoka/agent/spec/controls/input.ex
    lib/jidoka/agent/spec/result.ex
    lib/jidoka/agent/verifiers
    lib/jidoka/agent/verifiers/verify_agent.ex
    lib/jidoka/agent/verifiers/verify_tools.ex
    lib/jidoka/agent/verifiers/verify_controls.ex
    lib/jidoka/agent/tool_sources
    lib/jidoka/agent/tool_sources/handoff.ex
    lib/jidoka/agent/tool_sources/action.ex
    lib/jidoka/agent/tool_sources/catalog.ex
    lib/jidoka/agent/tool_sources/skill.ex
    lib/jidoka/agent/tool_sources/subagent.ex
    lib/jidoka/agent/tool_sources/workflow.ex
    lib/jidoka/agent/tool_sources/ash_resource.ex
    lib/jidoka/agent/tool_sources/browser.ex
    lib/jidoka/agent/tool_sources/common.ex
    lib/jidoka/agent/tool_sources/mcp.ex
    lib/jidoka/agent/state.ex
    lib/jidoka/agent/control_compiler.ex
    lib/jidoka/agent/dsl
    lib/jidoka/agent/dsl/sections
    lib/jidoka/agent/dsl/sections/tools.ex
    lib/jidoka/agent/dsl/sections/tools
    lib/jidoka/agent/dsl/sections/tools/core.ex
    lib/jidoka/agent/dsl/sections/tools/orchestration.ex
    lib/jidoka/agent/dsl/sections/controls.ex
    lib/jidoka/agent/dsl/sections/agent.ex
    lib/jidoka/agent/dsl/entities.ex
    lib/jidoka/memory.ex
    lib/jidoka/turn
    lib/jidoka/turn/transition.ex
    lib/jidoka/turn/request.ex
    lib/jidoka/turn/plan.ex
    lib/jidoka/turn/state
    lib/jidoka/turn/state/operation_planner.ex
    lib/jidoka/turn/state.ex
    lib/jidoka/turn/cursor.ex
    lib/jidoka/turn/result.ex
    lib/jidoka/inspection
    lib/jidoka/inspection/preflight.ex
    lib/jidoka/eval.ex
    lib/jidoka/controls
    lib/jidoka/controls/max_input_length.ex
    lib/jidoka/controls/require_approval.ex
    lib/jidoka/controls/require_context.ex
    lib/jidoka/harness
    lib/jidoka/harness/session.ex
    lib/jidoka/harness/store.ex
    lib/jidoka/harness/replay.ex
    lib/jidoka/harness/store
    lib/jidoka/harness/store/in_memory.ex
    lib/jidoka/browser
    lib/jidoka/browser/tools
    lib/jidoka/browser/tools/search_web.ex
    lib/jidoka/browser/tools/read_page.ex
    lib/jidoka/browser/tools/snapshot_url.ex
    lib/jidoka/browser/runtime.ex
    lib/jidoka/workflow.ex
    lib/jidoka/projection.ex
    lib/jidoka/review
    lib/jidoka/review/interrupt.ex
    lib/jidoka/review/response.ex
    lib/jidoka/review/policy.ex
    lib/jidoka/review/request.ex
    lib/jidoka/review/approval.ex
    lib/jidoka/workflow
    lib/jidoka/workflow/graph.ex
    lib/jidoka/workflow/parameters_schema.ex
    lib/jidoka/workflow/spec.ex
    lib/jidoka/workflow/runtime.ex
    lib/jidoka/workflow/lua.ex
    lib/jidoka/workflow/spark_dsl.ex
    lib/jidoka/workflow/dsl.ex
    lib/jidoka/workflow/runtime
    lib/jidoka/workflow/runtime/value.ex
    lib/jidoka/workflow/runtime/step_runner.ex
    lib/jidoka/workflow/runtime/retry.ex
    lib/jidoka/workflow/lua
    lib/jidoka/workflow/lua/policy.ex
    lib/jidoka/workflow/lua/plan
    lib/jidoka/workflow/lua/plan/spec.ex
    lib/jidoka/workflow/lua/plan/spec
    lib/jidoka/workflow/lua/plan/spec/graph.ex
    lib/jidoka/workflow/lua/plan/spec/helpers.ex
    lib/jidoka/workflow/lua/plan/ref.ex
    lib/jidoka/workflow/lua/plan.ex
    lib/jidoka/workflow/lua/call_trace.ex
    lib/jidoka/workflow/codegen.ex
    lib/jidoka/workflow/definition
    lib/jidoka/workflow/definition/graph.ex
    lib/jidoka/workflow/definition/steps.ex
    lib/jidoka/workflow/definition/targets.ex
    lib/jidoka/workflow/definition/error.ex
    lib/jidoka/workflow/definition/validation.ex
    lib/jidoka/workflow/definition/refs.ex
    lib/jidoka/workflow/step.ex
    lib/jidoka/workflow/ref.ex
    lib/jidoka/workflow/definition.ex
    lib/jidoka/workflow/dsl
    lib/jidoka/workflow/dsl/error.ex
    lib/jidoka/workflow/dsl/entities.ex
    lib/jidoka/workflow/dsl/helpers.ex
    lib/jidoka/workflow/retry_policy.ex
    lib/jidoka/jido.ex
    lib/jidoka/usage.ex
    lib/jidoka/schema.ex
    lib/jidoka/inspection.ex
    lib/jidoka/eval
    lib/jidoka/eval/run.ex
    lib/jidoka/eval/case.ex
    lib/jidoka/browser.ex
    lib/jidoka/application.ex
    lib/jidoka/context.ex
    lib/jidoka/import
    lib/jidoka/import/registry.ex
    lib/jidoka/import/normalize.ex
    lib/jidoka/import/tools.ex
    lib/jidoka/import/decoder.ex
    lib/jidoka/import/controls.ex
    lib/jidoka/import/agent_document.ex
    lib/jidoka/kino
    lib/jidoka/kino/context_view.ex
    lib/jidoka/kino/agent_view.ex
    lib/jidoka/kino/runtime_setup.ex
    lib/jidoka/kino/render.ex
    lib/jidoka/kino/trace_view.ex
    lib/jidoka/kino/chat.ex
    lib/jidoka/error
    lib/jidoka/error/normalize.ex
    lib/jidoka/error/format.ex
    lib/jidoka/error/normalize
    lib/jidoka/error/normalize/runtime.ex
    lib/jidoka/error/normalize/helpers.ex
    lib/jidoka/error/normalize/basic.ex
    lib/jidoka/agent.ex
    lib/jidoka/debug.ex
    lib/jidoka/debug
    lib/jidoka/debug/diagnostics.ex
    lib/jidoka/debug/request_summary.ex
    lib/jidoka/debug/replay_diagnostics.ex
    lib/jidoka/projection
    lib/jidoka/projection/metadata.ex
    lib/jidoka/projection/workflow.ex
    lib/jidoka/projection/value.ex
    lib/jidoka/projection/agent_spec.ex
    lib/mix
    lib/mix/tasks
    lib/mix/tasks/jidoka.example.ex
    lib/mix/tasks/jidoka.examples.check.ex
    lib/jidoka.ex
    guides
    guides/ash-jido.md
    guides/idempotency-and-safety.md
    guides/workflows.md
    guides/sessions-and-stores.md
    guides/agent-orchestration.md
    guides/projection-internals.md
    guides/contributor-testing.md
    guides/runic-spine-internals.md
    guides/operation-source-contracts.md
    guides/tracing-and-events.md
    guides/agent-dsl.md
    guides/troubleshooting.md
    guides/glossary.md
    guides/tools-and-operations.md
    guides/handoffs.md
    guides/snapshots-and-resume.md
    guides/turn-runner-and-effect-interpreter.md
    guides/streaming.md
    guides/jido-process-integration.md
    guides/getting-started.md
    guides/structured-results.md
    guides/runtime-capabilities-internals.md
    guides/memory.md
    guides/import-json-yaml.md
    guides/configuration.md
    guides/errors-and-config-reference.md
    guides/memory-contracts.md
    guides/agent-view.md
    guides/controls.md
    guides/import-and-snapshot-contracts.md
    guides/documentation-overview.md
    guides/livebooks
    guides/livebooks/controls_sessions_and_human_review.livemd
    guides/livebooks/import_eval_and_trace.livemd
    guides/livebooks/workflows.livemd
    guides/livebooks/contracts_and_runtime.livemd
    guides/public-facade.md
    guides/kino-notebooks.md
    guides/live-llm-tool-loop.md
    guides/human-in-the-loop.md
    guides/testing-and-evals.md
    guides/skill-workflow-subagent-tools.md
    guides/mcp-tools.md
    guides/browser-tools.md
    guides/core-concepts.md
    guides/turn-and-effect-contracts.md
    guides/agent-spec-contract.md
    guides/inspection-and-preflight.md
    guides/runtime-and-harness.md
    examples
    examples/_support
    examples/_support/ex_unit_formatter.ex
    examples/_support/reporter.ex
    examples/_support/check.exs
    examples/_support/timeouts.ex
    examples/_support/catalog.exs
    examples/_support/test_support.ex
    examples/_support/check_livebook.exs
    examples/_support/planner.ex
    examples/_support/shared
    examples/_support/shared/mock_llm.ex
    examples/_support/registry.exs
    examples/_support/test_helper.exs
    examples/_support/executor.ex
    examples/_support/model.ex
    examples/README.md
    examples/support_agent
    examples/support_agent/test
    examples/support_agent/test/controlled_tool_call_test.exs
    examples/support_agent/README.md
    examples/support_agent/manifest.yaml
    examples/support_agent/support_agent.livemd
    examples/support_agent/lib
    examples/support_agent/lib/controls
    examples/support_agent/lib/controls/require_order_approval.ex
    examples/support_agent/lib/actions
    examples/support_agent/lib/actions/lookup_order.ex
    examples/support_agent/lib/agent.ex
    examples/support_agent/example.exs
    .formatter.exs
    mix.exs
    README.md
    CHANGELOG.md
    CONTRIBUTING.md
    usage-rules.md
    LICENSE
  Version: 0.8.0-beta.1
  Build tools: mix
  Description: A data-driven agent framework for the Jido ecosystem with a Spark DSL and durable turn runtime.
  Licenses: Apache-2.0
  Links: 
    Changelog: https://hexdocs.pm/jidoka/changelog.html
    Discord: https://jido.run/discord
    Documentation: https://hexdocs.pm/jidoka
    GitHub: https://github.com/agentjido/jidoka
    Website: https://jido.run
  Elixir: ~> 1.18
Saved to jidoka-0.8.0-beta.1\n- GitHub CI — all required checks passed on Elixir 1.18 through 1.20\n\nCloses #28