### PR TITLE
feat(policy): add restricted v0.1 execution contracts

### DIFF
--- a/lib/jidoka/event.ex
+++ b/lib/jidoka/event.ex
@@ -31,6 +31,8 @@ defmodule Jidoka.Event do
     capability_call_failed: %{category: :runtime, phase: :interpret_effect, status: :failed},
     policy_allowed: %{category: :policy, phase: :policy, status: :completed},
     policy_denied: %{category: :policy, phase: :policy, status: :failed},
+    policy_consent_required: %{category: :policy, phase: :policy, status: :pending},
+    policy_unsupported: %{category: :policy, phase: :policy, status: :failed},
     policy_review_requested: %{category: :policy, phase: :policy, status: :pending},
     control_allowed: %{category: :control, phase: :control, status: :completed},
     control_blocked: %{category: :control, phase: :control, status: :failed},

--- a/lib/jidoka/execution_environment/restricted_contract.ex
+++ b/lib/jidoka/execution_environment/restricted_contract.ex
@@ -1,0 +1,169 @@
+defmodule Jidoka.ExecutionEnvironment.RestrictedContract do
+  @moduledoc """
+  Additive v0.1 contracts for the restricted local execution path.
+
+  These types describe explicit roots, environment allowlists, credential
+  references, network policy, resource limits, cancellation, deadlines, and
+  cleanup evidence. Unknown bounded fields remain data and never grant
+  authority.
+  """
+
+  alias Jidoka.ExecutionEnvironment.Contract
+  alias Jidoka.Schema
+
+  @version 1
+  @root_kinds [:workspace, :toolchain, :artifact, :temporary]
+  @network_scopes [:loopback, :external]
+  @network_decisions [:allow, :deny]
+  @cleanup_statuses [:clean, :failed, :unknown]
+
+  @type t :: %{
+          optional(:version) => pos_integer(),
+          required(:profile_id) => String.t(),
+          required(:roots) => [map()],
+          required(:environment) => map(),
+          optional(:credentials) => [map()],
+          optional(:network) => [map()],
+          optional(:resources) => map(),
+          required(:cancellation) => map(),
+          required(:deadline_ms) => pos_integer(),
+          required(:cleanup) => map(),
+          optional(:unknown) => map()
+        }
+
+  @doc "Returns the restricted-contract schema version."
+  @spec version() :: pos_integer()
+  def version, do: @version
+
+  @doc "Returns the declared root kinds for the v0.1 restricted path."
+  @spec root_kinds() :: [atom()]
+  def root_kinds, do: @root_kinds
+
+  @doc "Returns the restricted-contract schema."
+  @spec schema() :: Zoi.schema()
+  def schema do
+    Zoi.map(
+      %{
+        version: Zoi.literal(@version) |> Zoi.default(@version),
+        profile_id: Schema.non_empty_string(),
+        roots: Zoi.array(root_schema()) |> Zoi.min(1),
+        environment: environment_schema(),
+        credentials: Zoi.array(credential_schema()) |> Zoi.default([]),
+        network: Zoi.array(network_schema()) |> Zoi.default([]),
+        resources: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_limits, []}),
+        cancellation: cancellation_schema(),
+        deadline_ms: Zoi.integer() |> Zoi.gte(1),
+        cleanup: cleanup_schema(),
+        unknown: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_safe_map, []})
+      },
+      coerce: true
+    )
+  end
+
+  @doc "Builds one restricted v0.1 execution contract."
+  @spec new(keyword() | map()) :: {:ok, t()} | {:error, term()}
+  def new(attrs), do: Zoi.parse(schema(), Schema.normalize_attrs(attrs))
+
+  @doc "Builds one restricted v0.1 execution contract and raises on invalid input."
+  @spec new!(keyword() | map()) :: t()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, value} -> value
+      {:error, reason} -> raise ArgumentError, "invalid restricted execution contract: #{inspect(reason)}"
+    end
+  end
+
+  @doc "Returns the compatibility identity for the v0.1 restricted contract."
+  @spec compatibility() :: map()
+  def compatibility do
+    %{
+      "contract" => "jidoka.execution.restricted",
+      "version" => @version,
+      "release_target" => "v0.1",
+      "policy_outcomes" => Enum.map(Jidoka.Policy.Decision.outcomes(), &Atom.to_string/1),
+      "root_kinds" => Enum.map(@root_kinds, &Atom.to_string/1),
+      "network_scopes" => Enum.map(@network_scopes, &Atom.to_string/1)
+    }
+  end
+
+  @doc "Validates that a contract satisfies the v0.1 restricted compatibility matrix."
+  @spec compatible?(t()) :: :ok | {:error, term()}
+  def compatible?(contract) when is_map(contract) do
+    kinds =
+      contract
+      |> field(:roots)
+      |> List.wrap()
+      |> Enum.map(&root_kind/1)
+      |> Enum.sort()
+
+    cond do
+      kinds != Enum.sort(@root_kinds) ->
+        {:error, {:missing_required_roots, kinds}}
+
+      field(field(contract, :environment), :private_home) != true ->
+        {:error, :private_home_required}
+
+      field(field(contract, :cancellation), :enabled) != true ->
+        {:error, :cancellation_required}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp root_schema do
+    Zoi.map(%{
+      kind: Schema.atom_enum(@root_kinds),
+      digest: Schema.non_empty_string() |> Zoi.refine({Contract, :validate_digest, []}),
+      writable: Zoi.boolean(),
+      unknown: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_safe_map, []})
+    })
+  end
+
+  defp environment_schema do
+    Zoi.map(%{
+      allowlist: Zoi.array(Schema.non_empty_string()),
+      private_home: Zoi.boolean(),
+      unknown: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_safe_map, []})
+    })
+  end
+
+  defp credential_schema do
+    Zoi.map(%{
+      provider: Schema.non_empty_string(),
+      source: Schema.non_empty_string(),
+      reference: Schema.non_empty_string() |> Zoi.refine({Contract, :validate_opaque_ref, []}),
+      unknown: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_safe_map, []})
+    })
+  end
+
+  defp network_schema do
+    Zoi.map(%{
+      scope: Schema.atom_enum(@network_scopes),
+      decision: Schema.atom_enum(@network_decisions),
+      unknown: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_safe_map, []})
+    })
+  end
+
+  defp cancellation_schema do
+    Zoi.map(%{
+      enabled: Zoi.boolean(),
+      deadline_ms: Zoi.integer() |> Zoi.gte(1) |> Zoi.nullish(),
+      unknown: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_safe_map, []})
+    })
+  end
+
+  defp root_kind(root), do: field(root, :kind)
+
+  defp field(map, key) when is_map(map) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key)))
+  end
+
+  defp cleanup_schema do
+    Zoi.map(%{
+      status: Schema.atom_enum(@cleanup_statuses),
+      child_processes: Zoi.integer() |> Zoi.gte(0),
+      unknown: Zoi.map() |> Zoi.default(%{}) |> Zoi.refine({Contract, :validate_safe_map, []})
+    })
+  end
+end

--- a/lib/jidoka/execution_environment/restricted_contract.ex
+++ b/lib/jidoka/execution_environment/restricted_contract.ex
@@ -96,9 +96,11 @@ defmodule Jidoka.ExecutionEnvironment.RestrictedContract do
       |> Enum.map(&root_kind/1)
       |> Enum.sort()
 
+    missing = @root_kinds -- kinds
+
     cond do
-      kinds != Enum.sort(@root_kinds) ->
-        {:error, {:missing_required_roots, kinds}}
+      missing != [] ->
+        {:error, {:missing_required_roots, missing}}
 
       field(field(contract, :environment), :private_home) != true ->
         {:error, :private_home_required}
@@ -158,6 +160,8 @@ defmodule Jidoka.ExecutionEnvironment.RestrictedContract do
   defp field(map, key) when is_map(map) do
     Map.get(map, key, Map.get(map, Atom.to_string(key)))
   end
+
+  defp field(_other, _key), do: nil
 
   defp cleanup_schema do
     Zoi.map(%{

--- a/lib/jidoka/policy/decision.ex
+++ b/lib/jidoka/policy/decision.ex
@@ -2,15 +2,16 @@ defmodule Jidoka.Policy.Decision do
   @moduledoc """
   Portable evidence from the authoritative host policy gate.
 
-  A decision allows, denies, or pauses one protected effect for review. The
-  rule identifier and evidence describe the host rule that made the decision.
+  A decision allows, denies, requires consent, marks a request unsupported, or
+  pauses one protected effect for review. The rule identifier and evidence
+  describe the host rule that made the decision.
   """
 
   alias Jidoka.Policy.Request
   alias Jidoka.Schema
 
   @version 1
-  @outcomes [:allow, :deny, :require_review]
+  @outcomes [:allow, :deny, :consent_required, :unsupported, :require_review]
 
   @schema Zoi.struct(
             __MODULE__,
@@ -26,7 +27,7 @@ defmodule Jidoka.Policy.Decision do
           )
           |> Zoi.refine({__MODULE__, :validate_portable, []})
 
-  @type outcome :: :allow | :deny | :require_review
+  @type outcome :: :allow | :deny | :consent_required | :unsupported | :require_review
   @type t :: unquote(Zoi.type_spec(@schema))
   @enforce_keys Zoi.Struct.enforce_keys(@schema)
   defstruct Zoi.Struct.struct_fields(@schema)

--- a/lib/jidoka/policy/gate.ex
+++ b/lib/jidoka/policy/gate.ex
@@ -104,6 +104,14 @@ defmodule Jidoka.Policy.Gate do
     {:deny, decision, append_decision_event(state, intent, decision, :policy_denied, opts)}
   end
 
+  defp apply_decision(state, intent, %Decision{outcome: :consent_required} = decision, opts) do
+    {:deny, decision, append_decision_event(state, intent, decision, :policy_consent_required, opts)}
+  end
+
+  defp apply_decision(state, intent, %Decision{outcome: :unsupported} = decision, opts) do
+    {:deny, decision, append_decision_event(state, intent, decision, :policy_unsupported, opts)}
+  end
+
   defp apply_decision(state, intent, %Decision{outcome: :require_review} = decision, opts) do
     if approved?(intent) do
       {:allow, decision, append_decision_event(state, intent, decision, :policy_allowed, opts)}
@@ -203,6 +211,8 @@ defmodule Jidoka.Policy.Gate do
 
   defp allowed(%Decision{outcome: :allow}), do: :ok
   defp allowed(%Decision{outcome: :deny, reason: reason}), do: {:error, {:policy_denied, reason}}
+  defp allowed(%Decision{outcome: :consent_required, reason: reason}), do: {:error, {:policy_consent_required, reason}}
+  defp allowed(%Decision{outcome: :unsupported, reason: reason}), do: {:error, {:policy_unsupported, reason}}
   defp allowed(%Decision{outcome: :require_review}), do: {:error, :policy_review_required}
 
   defp invoke(policy, request, context, opts) do

--- a/test/jidoka/execution_environment/restricted_contract_test.exs
+++ b/test/jidoka/execution_environment/restricted_contract_test.exs
@@ -14,12 +14,18 @@ defmodule Jidoka.ExecutionEnvironment.RestrictedContractTest do
     attrs = valid_attrs()
     roots = Enum.reject(attrs.roots, &(&1.kind == :temporary))
 
-    assert {:error, {:missing_required_roots, _kinds}} =
+    assert {:error, {:missing_required_roots, [:temporary]}} =
              attrs |> Map.put(:roots, roots) |> RestrictedContract.new!() |> RestrictedContract.compatible?()
 
     assert {:error, :private_home_required} =
              attrs
              |> put_in([:environment, :private_home], false)
+             |> RestrictedContract.new!()
+             |> RestrictedContract.compatible?()
+
+    assert {:error, :cancellation_required} =
+             attrs
+             |> put_in([:cancellation, :enabled], false)
              |> RestrictedContract.new!()
              |> RestrictedContract.compatible?()
   end

--- a/test/jidoka/execution_environment/restricted_contract_test.exs
+++ b/test/jidoka/execution_environment/restricted_contract_test.exs
@@ -1,0 +1,57 @@
+defmodule Jidoka.ExecutionEnvironment.RestrictedContractTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.ExecutionEnvironment.RestrictedContract
+
+  test "builds the v0.1 restricted contract and passes compatibility" do
+    assert {:ok, contract} = RestrictedContract.new(valid_attrs())
+    assert :ok = RestrictedContract.compatible?(contract)
+    assert RestrictedContract.compatibility()["release_target"] == "v0.1"
+    assert "consent_required" in RestrictedContract.compatibility()["policy_outcomes"]
+  end
+
+  test "requires explicit roots, private home, and cancellation" do
+    attrs = valid_attrs()
+    roots = Enum.reject(attrs.roots, &(&1.kind == :temporary))
+
+    assert {:error, {:missing_required_roots, _kinds}} =
+             attrs |> Map.put(:roots, roots) |> RestrictedContract.new!() |> RestrictedContract.compatible?()
+
+    assert {:error, :private_home_required} =
+             attrs
+             |> put_in([:environment, :private_home], false)
+             |> RestrictedContract.new!()
+             |> RestrictedContract.compatible?()
+  end
+
+  test "rejects raw host paths as credential references" do
+    attrs = put_in(valid_attrs(), [:credentials], [%{provider: "openai", source: "env", reference: "/etc/secret"}])
+    assert {:error, _reason} = RestrictedContract.new(attrs)
+  end
+
+  test "preserves bounded unknown fields without granting authority" do
+    attrs = put_in(valid_attrs(), [:unknown], %{"future" => "data"})
+    assert {:ok, contract} = RestrictedContract.new(attrs)
+    assert contract.unknown["future"] == "data"
+    assert :ok = RestrictedContract.compatible?(contract)
+  end
+
+  defp valid_attrs do
+    digest = Jidoka.ExecutionEnvironment.digest(%{"root" => "fixture"})
+
+    %{
+      profile_id: "coding.restricted",
+      roots:
+        Enum.map(RestrictedContract.root_kinds(), fn kind ->
+          %{kind: kind, digest: digest, writable: kind != :toolchain}
+        end),
+      environment: %{allowlist: ["PATH", "LANG"], private_home: true},
+      credentials: [%{provider: "openai", source: "host_env", reference: "env:OPENAI_API_KEY"}],
+      network: [%{scope: :loopback, decision: :deny}, %{scope: :external, decision: :deny}],
+      resources: %{"wall_time_ms" => 30_000},
+      cancellation: %{enabled: true, deadline_ms: 1_000},
+      deadline_ms: 30_000,
+      cleanup: %{status: :clean, child_processes: 0}
+    }
+  end
+end

--- a/test/jidoka/policy/restricted_v01_contract_test.exs
+++ b/test/jidoka/policy/restricted_v01_contract_test.exs
@@ -1,0 +1,46 @@
+defmodule Jidoka.Policy.RestrictedV01ContractTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.Policy.Decision
+  alias Jidoka.Policy.Gate
+  alias Jidoka.Policy.Request
+
+  test "policy decisions represent allow, deny, consent-required, and unsupported" do
+    assert :allow in Decision.outcomes()
+    assert :deny in Decision.outcomes()
+    assert :consent_required in Decision.outcomes()
+    assert :unsupported in Decision.outcomes()
+
+    Enum.each([:allow, :deny, :consent_required, :unsupported], fn outcome ->
+      assert {:ok, %Decision{outcome: ^outcome}} =
+               Decision.new(outcome: outcome, rule_id: "host.#{outcome}")
+    end)
+  end
+
+  test "bounded unknown policy evidence does not grant authority" do
+    assert {:ok, decision} =
+             Decision.new(
+               outcome: :deny,
+               rule_id: "host.unknown",
+               evidence: %{"future_field" => %{"note" => "ignored"}}
+             )
+
+    assert decision.outcome == :deny
+    assert decision.evidence["future_field"]["note"] == "ignored"
+  end
+
+  test "gate check fails closed for consent-required and unsupported" do
+    request = Request.new!(effect_class: :llm, action: "model.invoke", request_id: "req")
+
+    consent = fn _request, _context ->
+      {:ok, Decision.new!(outcome: :consent_required, rule_id: "host.consent", reason: :boundary)}
+    end
+
+    unsupported = fn _request, _context ->
+      {:ok, Decision.new!(outcome: :unsupported, rule_id: "host.unsupported", reason: :feature)}
+    end
+
+    assert {:error, {:policy_consent_required, :boundary}} = Gate.check(request, consent, [])
+    assert {:error, {:policy_unsupported, :feature}} = Gate.check(request, unsupported, [])
+  end
+end


### PR DESCRIPTION
## Summary

Adds the additive Jidoka contracts required by Jido Console Milestone 1 restricted execution (jido_console-m1e04).

- Policy decisions now represent `allow`, `deny`, `consent_required`, `unsupported`, and `require_review`.
- Gate checks fail closed for consent-required and unsupported outcomes.
- New `Jidoka.ExecutionEnvironment.RestrictedContract` describes explicit roots, environment allowlists, credential references, network policy, resources, cancellation, deadlines, and cleanup evidence.
- Bounded unknown fields remain data and cannot grant authority.
- Compatibility identity targets the v0.1 restricted path.

This pull request contains only additive Jidoka contracts. It does not integrate Jido Console.

## Test plan

- [x] `mix test test/jidoka/policy test/jidoka/execution_environment`