### PR TITLE
feat(events): land the ordered async request stream contract

### DIFF
--- a/guides/tracing-and-events.md
+++ b/guides/tracing-and-events.md
@@ -95,6 +95,14 @@ sampling, and redaction when callers want a timeline.
   (`:control_allowed/blocked/interrupted/failed`), review lifecycle
   (`:approval_requested/responded/applied`), result validation, memory, and
   `:llm_delta` for streamed tokens.
+- [`Jidoka.Event.Order`](`Jidoka.Event.Order`) defines the public request-stream
+  order contract. The async request controller is the one sequence owner. One
+  request stream uses one non-empty `request_id`, starts with `seq: 0`,
+  increments `seq` by one, and has exactly one terminal `:turn_finished`,
+  `:turn_failed`, or `:turn_hibernated` event. Completion, cancellation,
+  timeout, and owner-exit races still emit that one terminal. An event that
+  cannot be classified onto the request is rejected and cannot create a second
+  terminal.
 - Categories are `:workflow`, `:effect`, `:runtime`, `:operation`,
   `:control`, `:approval`, `:result`, and `:memory`. Phases partition the
   workflow into `:start`, `:control`, `:review`, `:memory`,
@@ -241,6 +249,12 @@ caring about which snapshot produced which events.
 
 Use the in-memory sink and a deterministic LLM to assert on the projected
 timeline.
+
+For a collected live stream, check the order contract directly:
+
+```elixir
+:ok = Jidoka.Event.Order.validate(events)
+```
 
 ```elixir
 test "in-memory sink records projected entries" do

--- a/lib/jidoka/chat/request_controller.ex
+++ b/lib/jidoka/chat/request_controller.ex
@@ -152,6 +152,7 @@ defmodule Jidoka.Chat.RequestController do
         {:DOWN, owner_monitor, :process, owner, _reason},
         %{owner: owner, owner_monitor: owner_monitor} = state
       ) do
+    _shutdown = Task.shutdown(state.task, :brutal_kill)
     {:stop, :normal, finish_race(state, {:error, :owner_exited})}
   end
 
@@ -313,7 +314,9 @@ defmodule Jidoka.Chat.RequestController do
   defp finish(state, result) do
     cancel_timeout(state)
     Enum.each(state.awaiters, &GenServer.reply(&1, result))
-    %{state | status: :finished, result: result, awaiters: []}
+    Enum.each(state.cancellers, &GenServer.reply(&1, {:error, :request_already_finished}))
+
+    %{state | status: :finished, result: result, awaiters: [], cancellers: []}
   end
 
   defp cancel_timeout(%{timeout_ref: ref}) when is_reference(ref), do: Process.cancel_timer(ref)

--- a/lib/jidoka/chat/request_controller.ex
+++ b/lib/jidoka/chat/request_controller.ex
@@ -6,6 +6,7 @@ defmodule Jidoka.Chat.RequestController do
   alias Jidoka.Cancellation
   alias Jidoka.Cancellation.Token
   alias Jidoka.Event
+  alias Jidoka.Event.Order
   alias Jidoka.Runtime.EventDispatcher
 
   @task_supervisor Jidoka.Chat.TaskSupervisor
@@ -57,6 +58,7 @@ defmodule Jidoka.Chat.RequestController do
     runtime_opts = Keyword.fetch!(opts, :runtime_opts)
     fun = Keyword.fetch!(opts, :fun)
     token = Token.new()
+    timeout_ms = positive_integer(Keyword.get(runtime_opts, :request_timeout_ms), nil)
 
     worker_opts =
       runtime_opts
@@ -66,6 +68,7 @@ defmodule Jidoka.Chat.RequestController do
       |> Keyword.put(:cancellation, token)
 
     task = Task.Supervisor.async_nolink(@task_supervisor, fn -> fun.(worker_opts) end)
+    timeout_ref = if timeout_ms, do: Process.send_after(self(), :request_timeout, timeout_ms)
 
     {:ok,
      %{
@@ -86,7 +89,8 @@ defmodule Jidoka.Chat.RequestController do
        cancellers: [],
        cancellation_members: %{},
        next_seq: 0,
-       agent_id: nil
+       agent_id: nil,
+       timeout_ref: timeout_ref
      }}
   end
 
@@ -139,9 +143,24 @@ defmodule Jidoka.Chat.RequestController do
 
   def handle_info(
         {:DOWN, owner_monitor, :process, owner, _reason},
-        %{owner: owner, owner_monitor: owner_monitor} = state
+        %{owner: owner, owner_monitor: owner_monitor, status: :finished} = state
       ) do
     {:stop, :normal, state}
+  end
+
+  def handle_info(
+        {:DOWN, owner_monitor, :process, owner, _reason},
+        %{owner: owner, owner_monitor: owner_monitor} = state
+      ) do
+    {:stop, :normal, finish_race(state, {:error, :owner_exited})}
+  end
+
+  def handle_info(:request_timeout, %{status: :finished} = state), do: {:noreply, state}
+
+  def handle_info(:request_timeout, state) do
+    _shutdown = Task.shutdown(state.task, :brutal_kill)
+    terminate_cancellation_members(state)
+    {:noreply, finish_race(state, {:error, :request_timeout})}
   end
 
   def handle_info({:DOWN, monitor_ref, :process, pid, _reason}, state) do
@@ -188,7 +207,14 @@ defmodule Jidoka.Chat.RequestController do
 
   defp accept_event(%{terminal?: true} = state, _event), do: state
 
-  defp accept_event(%{cancellation_requested?: true} = state, %Event{} = event) do
+  defp accept_event(state, %Event{} = event) do
+    case Order.classify(event, state.request_id) do
+      :accept -> accept_classified_event(state, event)
+      {:reject, _reason} -> state
+    end
+  end
+
+  defp accept_classified_event(%{cancellation_requested?: true} = state, %Event{} = event) do
     if EventDispatcher.terminal?(event) do
       state
       |> maybe_forward_cancel_event(event)
@@ -198,7 +224,7 @@ defmodule Jidoka.Chat.RequestController do
     end
   end
 
-  defp accept_event(state, %Event{} = event) do
+  defp accept_classified_event(state, %Event{} = event) do
     state = forward_event(state, event)
 
     cond do
@@ -276,10 +302,22 @@ defmodule Jidoka.Chat.RequestController do
     finish(%{state | cancellers: []}, {:cancelled, cancellation})
   end
 
+  defp finish_race(%{status: :finished} = state, _result), do: state
+
+  defp finish_race(state, result) do
+    state
+    |> ensure_terminal_for_result(result)
+    |> finish(result)
+  end
+
   defp finish(state, result) do
+    cancel_timeout(state)
     Enum.each(state.awaiters, &GenServer.reply(&1, result))
     %{state | status: :finished, result: result, awaiters: []}
   end
+
+  defp cancel_timeout(%{timeout_ref: ref}) when is_reference(ref), do: Process.cancel_timer(ref)
+  defp cancel_timeout(_state), do: false
 
   defp ensure_cancellation_terminal(%{terminal?: true} = state), do: state
 
@@ -326,7 +364,14 @@ defmodule Jidoka.Chat.RequestController do
   end
 
   defp forward_event(state, %Event{} = event) do
-    :ok = EventDispatcher.emit(event, stream_to: state.stream_to, on_event: state.on_event)
+    event = %Event{event | seq: state.next_seq, request_id: state.request_id}
+
+    :ok =
+      EventDispatcher.emit(event,
+        stream_to: state.stream_to,
+        on_event: state.on_event,
+        sequence: false
+      )
 
     %{
       state

--- a/lib/jidoka/event/order.ex
+++ b/lib/jidoka/event/order.ex
@@ -1,0 +1,79 @@
+defmodule Jidoka.Event.Order do
+  @moduledoc """
+  Public order contract for one streamed request.
+
+  The request controller is the single sequence owner. It assigns contiguous
+  `seq` values starting at zero, forwards only events that classify onto the
+  request, and emits exactly one terminal event. Completion, cancellation,
+  timeout, and owner-exit races must still produce that one terminal result.
+  A late or unassignable event cannot create a second terminal.
+  """
+
+  alias Jidoka.Event
+
+  @terminal_events [:turn_finished, :turn_failed, :turn_hibernated]
+
+  @type violation ::
+          :empty_events
+          | :missing_terminal
+          | {:missing_request_id, non_neg_integer()}
+          | {:mixed_request_id, String.t(), String.t(), non_neg_integer()}
+          | {:unexpected_sequence, non_neg_integer(), non_neg_integer()}
+          | {:event_after_terminal, non_neg_integer()}
+
+  @type classification ::
+          :accept
+          | {:reject, :missing_request_id | :foreign_request_id}
+
+  @doc "Checks one ordered event stream."
+  @spec validate([Event.t()]) :: :ok | {:error, violation()}
+  def validate([]), do: {:error, :empty_events}
+
+  def validate([%Event{request_id: request_id} | _events] = events)
+      when is_binary(request_id) do
+    events
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, false}, fn {%Event{} = event, index}, {:ok, terminal?} ->
+      cond do
+        not is_binary(event.request_id) ->
+          {:halt, {:error, {:missing_request_id, index}}}
+
+        event.request_id != request_id ->
+          {:halt, {:error, {:mixed_request_id, request_id, event.request_id, index}}}
+
+        event.seq != index ->
+          {:halt, {:error, {:unexpected_sequence, index, event.seq}}}
+
+        terminal? ->
+          {:halt, {:error, {:event_after_terminal, index}}}
+
+        true ->
+          {:cont, {:ok, event.event in @terminal_events}}
+      end
+    end)
+    |> case do
+      {:ok, true} -> :ok
+      {:ok, false} -> {:error, :missing_terminal}
+      {:error, _violation} = error -> error
+    end
+  end
+
+  def validate([%Event{} | _events]), do: {:error, {:missing_request_id, 0}}
+
+  @doc "Classifies whether an event belongs to one request sequence owner."
+  @spec classify(Event.t(), String.t()) :: classification()
+  def classify(%Event{request_id: request_id}, owner_id)
+      when is_binary(owner_id) and is_binary(request_id) do
+    if request_id == owner_id, do: :accept, else: {:reject, :foreign_request_id}
+  end
+
+  def classify(%Event{}, owner_id) when is_binary(owner_id), do: {:reject, :missing_request_id}
+
+  @doc "Returns true when an event closes an ordered request stream."
+  @spec terminal?(Event.t()) :: boolean()
+  def terminal?(%Event{event: event}), do: event in @terminal_events
+
+  @doc "Returns the event names that close an ordered request stream."
+  @spec terminal_events() :: [atom()]
+  def terminal_events, do: @terminal_events
+end

--- a/lib/jidoka/runtime/event_dispatcher.ex
+++ b/lib/jidoka/runtime/event_dispatcher.ex
@@ -15,7 +15,7 @@ defmodule Jidoka.Runtime.EventDispatcher do
 
   @spec emit(Event.t(), keyword()) :: :ok
   def emit(%Event{} = event, opts) when is_list(opts) do
-    event = EventSequence.stamp(event)
+    event = if Keyword.get(opts, :sequence, true), do: EventSequence.stamp(event), else: event
     emit_to_mailbox(event, Keyword.get(opts, :stream_to))
     emit_to_callback(event, Keyword.get(opts, :on_event))
     Jidoka.Extension.RuntimeEvents.emit_runtime(event, opts)

--- a/test/jidoka/event_order_test.exs
+++ b/test/jidoka/event_order_test.exs
@@ -151,6 +151,27 @@ defmodule Jidoka.EventOrderTest do
     assert :ok = Order.validate(events)
   end
 
+  test "request timeout resolves a pending cancellation call" do
+    parent = self()
+
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :ordered_target,
+               "Timeout during cancellation",
+               [request_id: "controller-cancel-timeout", request_timeout_ms: 100],
+               fn _opts ->
+                 send(parent, :cancel_timeout_worker_started)
+                 Process.sleep(:infinity)
+               end
+             )
+
+    assert_receive :cancel_timeout_worker_started, 1_000
+    cancellation = Task.async(fn -> Jidoka.cancel(request, grace_ms: 1_000) end)
+
+    assert {:error, :request_already_finished} = Task.await(cancellation, 1_000)
+    assert {:error, :request_timeout} = Jidoka.await(request, timeout: 1_000)
+  end
+
   test "owner exit races produce one terminal result" do
     parent = self()
 
@@ -161,7 +182,10 @@ defmodule Jidoka.EventOrderTest do
                    :ordered_target,
                    "Race owner",
                    [stream: true, request_id: "controller-owner-race", stream_to: parent],
-                   fn _opts -> Process.sleep(:infinity) end
+                   fn _opts ->
+                     send(parent, {:owner_worker, self()})
+                     Process.sleep(:infinity)
+                   end
                  )
 
         send(parent, {:owner_request, request})
@@ -169,6 +193,7 @@ defmodule Jidoka.EventOrderTest do
       end)
 
     assert_receive {:owner_request, _request}, 1_000
+    assert_receive {:owner_worker, worker}, 1_000
     Process.exit(owner, :kill)
     assert_receive {:jidoka_turn_event, %Event{event: terminal} = event}, 1_000
     assert Order.terminal?(event)
@@ -178,6 +203,7 @@ defmodule Jidoka.EventOrderTest do
     refute_receive {:jidoka_turn_event, %Event{event: :turn_hibernated}}, 100
     assert event.request_id == "controller-owner-race"
     assert event.data.reason == inspect(:owner_exited)
+    refute eventually_alive?(worker)
   end
 
   defp collect_request_events(request_id, fun) do
@@ -196,5 +222,17 @@ defmodule Jidoka.EventOrderTest do
 
   defp event(name, seq) do
     Event.build(name, [], request_id: "ordered-request", seq: seq)
+  end
+
+  defp eventually_alive?(pid, attempts \\ 20)
+  defp eventually_alive?(pid, 0), do: Process.alive?(pid)
+
+  defp eventually_alive?(pid, attempts) do
+    if Process.alive?(pid) do
+      Process.sleep(10)
+      eventually_alive?(pid, attempts - 1)
+    else
+      false
+    end
   end
 end

--- a/test/jidoka/event_order_test.exs
+++ b/test/jidoka/event_order_test.exs
@@ -1,0 +1,200 @@
+defmodule Jidoka.EventOrderTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.Event
+  alias Jidoka.Event.Order
+  alias Jidoka.Stream
+
+  test "accepts one contiguous request stream with one terminal event" do
+    events = [
+      event(:turn_started, 0),
+      event(:llm_delta, 1),
+      event(:turn_finished, 2)
+    ]
+
+    assert :ok = Order.validate(events)
+    assert Order.terminal?(List.last(events))
+  end
+
+  test "rejects reorder, mixed requests, missing terminals, and events after a terminal event" do
+    assert {:error, {:unexpected_sequence, 1, 2}} =
+             Order.validate([event(:turn_started, 0), event(:llm_delta, 2)])
+
+    assert {:error, {:mixed_request_id, "ordered-request", "other-request", 1}} =
+             Order.validate([
+               event(:turn_started, 0),
+               Event.build(:turn_finished, [], request_id: "other-request", seq: 1)
+             ])
+
+    assert {:error, {:event_after_terminal, 2}} =
+             Order.validate([
+               event(:turn_started, 0),
+               event(:turn_finished, 1),
+               event(:llm_delta, 2)
+             ])
+
+    assert {:error, :missing_terminal} = Order.validate([event(:turn_started, 0), event(:llm_delta, 1)])
+  end
+
+  test "classifies events that cannot join the request sequence" do
+    owner = event(:turn_started, 0)
+    assert :accept = Order.classify(owner, "ordered-request")
+
+    assert {:reject, :foreign_request_id} =
+             Order.classify(
+               Event.build(:llm_delta, [], request_id: "other-request", seq: 1),
+               "ordered-request"
+             )
+
+    assert {:reject, :missing_request_id} =
+             Order.classify(Event.build(:llm_delta, [], seq: 1), "ordered-request")
+  end
+
+  test "the async controller restamps worker events in mailbox order" do
+    events =
+      collect_request_events("controller-order", fn opts ->
+        :ok = Stream.emit(Event.build(:turn_started, [], request_id: "controller-order", seq: 40), opts)
+        :ok = Stream.emit(Event.build(:llm_delta, [], request_id: "controller-order", seq: 2), opts)
+        {:ok, "done"}
+      end)
+
+    assert Enum.map(events, & &1.seq) == Enum.to_list(0..(length(events) - 1))
+    assert :ok = Order.validate(events)
+    assert Enum.count(events, &Order.terminal?/1) == 1
+  end
+
+  test "foreign and late events cannot create a second terminal result" do
+    parent = self()
+
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :ordered_target,
+               "Reject extras",
+               [stream: true, request_id: "controller-reject"],
+               fn opts ->
+                 send(parent, {:controller, Keyword.fetch!(opts, :stream_to)})
+
+                 :ok =
+                   Stream.emit(
+                     Event.build(:turn_started, [], request_id: "controller-reject", seq: 0),
+                     opts
+                   )
+
+                 receive do
+                   :continue -> {:ok, "done"}
+                 end
+               end
+             )
+
+    assert_receive {:controller, controller}, 1_000
+
+    send(
+      controller,
+      {:jidoka_turn_event, Event.build(:turn_failed, [], request_id: "foreign-request", seq: 99)}
+    )
+
+    send(request.task.pid, :continue)
+
+    stream = Jidoka.stream(request, stream_event_timeout_ms: 100)
+    assert {:ok, "done"} = Jidoka.await(request, timeout: 1_000)
+    events = Enum.to_list(stream)
+
+    send(
+      request.controller,
+      {:jidoka_turn_event, Event.build(:turn_failed, [], request_id: "controller-reject", seq: 0)}
+    )
+
+    assert Enum.count(events, &Order.terminal?/1) == 1
+    assert :ok = Order.validate(events)
+    refute Enum.any?(events, &(&1.request_id == "foreign-request"))
+  end
+
+  test "completion and cancellation races produce one terminal result" do
+    parent = self()
+
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :ordered_target,
+               "Race cancel",
+               [stream: true, request_id: "controller-cancel-race"],
+               fn _opts ->
+                 send(parent, {:worker, self()})
+                 Process.sleep(:infinity)
+               end
+             )
+
+    assert_receive {:worker, _worker}, 1_000
+    stream = Jidoka.stream(request, stream_event_timeout_ms: 200)
+    assert {:ok, _cancellation} = Jidoka.cancel(request, grace_ms: 5)
+    assert {:cancelled, _cancellation} = Jidoka.await(request, timeout: 1_000)
+    events = Enum.to_list(stream)
+
+    assert Enum.count(events, &Order.terminal?/1) == 1
+    assert :ok = Order.validate(events)
+  end
+
+  test "request timeout races produce one terminal result" do
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :ordered_target,
+               "Race timeout",
+               [stream: true, request_id: "controller-timeout-race", request_timeout_ms: 20],
+               fn _opts -> Process.sleep(:infinity) end
+             )
+
+    stream = Jidoka.stream(request, stream_event_timeout_ms: 200)
+    assert {:error, :request_timeout} = Jidoka.await(request, timeout: 1_000)
+    events = Enum.to_list(stream)
+
+    assert Enum.count(events, &Order.terminal?/1) == 1
+    assert List.last(events).data.reason == inspect(:request_timeout)
+    assert :ok = Order.validate(events)
+  end
+
+  test "owner exit races produce one terminal result" do
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        assert {:ok, request} =
+                 Jidoka.Chat.Async.start_fun(
+                   :ordered_target,
+                   "Race owner",
+                   [stream: true, request_id: "controller-owner-race", stream_to: parent],
+                   fn _opts -> Process.sleep(:infinity) end
+                 )
+
+        send(parent, {:owner_request, request})
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:owner_request, _request}, 1_000
+    Process.exit(owner, :kill)
+    assert_receive {:jidoka_turn_event, %Event{event: terminal} = event}, 1_000
+    assert Order.terminal?(event)
+    assert terminal == :turn_failed
+    refute_receive {:jidoka_turn_event, %Event{event: :turn_finished}}, 100
+    refute_receive {:jidoka_turn_event, %Event{event: :turn_failed}}, 100
+    refute_receive {:jidoka_turn_event, %Event{event: :turn_hibernated}}, 100
+    assert event.request_id == "controller-owner-race"
+    assert event.data.reason == inspect(:owner_exited)
+  end
+
+  defp collect_request_events(request_id, fun) do
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :ordered_target,
+               "Order this",
+               [stream: true, request_id: request_id],
+               fun
+             )
+
+    stream = Jidoka.stream(request, stream_event_timeout_ms: 100)
+    assert {:ok, "done"} = Jidoka.await(request, timeout: 1_000)
+    Enum.to_list(stream)
+  end
+
+  defp event(name, seq) do
+    Event.build(name, [], request_id: "ordered-request", seq: seq)
+  end
+end


### PR DESCRIPTION
## Summary

- Makes the async request controller the single sequence owner for one Jidoka request.
- Emits a contiguous per-request event stream with exactly one terminal event.
- Classifies and rejects events that cannot be assigned to the request.
- Defines completion, cancellation, timeout, and owner-exit race behavior so a late or duplicate event cannot create a second terminal.

This is the Jidoka side of Jido Console Milestone 2 epic M2-E01 (`jido_console-m2e01`).

## Test plan

- [x] `mix test test/jidoka/event_order_test.exs`
- [ ] CI green