### PR TITLE
fix(runtime): stop completed request controllers

### DIFF
--- a/guides/streaming.md
+++ b/guides/streaming.md
@@ -104,6 +104,13 @@ Key facts:
   bounded cleanup. Capabilities can call
   `Jidoka.Cancellation.requested?/1` with their runtime context when they
   support their own cooperative cleanup.
+- The request controller keeps a terminal result for 30 seconds so a caller
+  can await it again. It then stops. `:request_retention_ms` can set a
+  smaller positive bound. After expiry, await and cancel return
+  `:request_expired` and do not restart work. Owner exit, timeout, error,
+  and cancellation stop the controller and its registered members. A
+  cleanup race cannot create a second terminal event or a second live
+  controller.
 
 ## How To
 

--- a/lib/jidoka/chat/request_controller.ex
+++ b/lib/jidoka/chat/request_controller.ex
@@ -13,6 +13,7 @@ defmodule Jidoka.Chat.RequestController do
   @request_supervisor Jidoka.Chat.RequestSupervisor
   @stream_message_tag :jidoka_turn_event
   @default_grace_ms 100
+  @default_retention_ms 30_000
 
   @type start_opts :: [
           request_id: String.t(),
@@ -59,6 +60,7 @@ defmodule Jidoka.Chat.RequestController do
     fun = Keyword.fetch!(opts, :fun)
     token = Token.new()
     timeout_ms = positive_integer(Keyword.get(runtime_opts, :request_timeout_ms), nil)
+    retention_ms = positive_integer(Keyword.get(runtime_opts, :request_retention_ms), @default_retention_ms)
 
     worker_opts =
       runtime_opts
@@ -90,7 +92,9 @@ defmodule Jidoka.Chat.RequestController do
        cancellation_members: %{},
        next_seq: 0,
        agent_id: nil,
-       timeout_ref: timeout_ref
+       timeout_ref: timeout_ref,
+       retention_ms: retention_ms,
+       expiry_ref: nil
      }}
   end
 
@@ -154,6 +158,10 @@ defmodule Jidoka.Chat.RequestController do
       ) do
     _shutdown = Task.shutdown(state.task, :brutal_kill)
     {:stop, :normal, finish_race(state, {:error, :owner_exited})}
+  end
+
+  def handle_info({:expire_request, expiry_ref}, %{status: :finished, expiry_ref: expiry_ref} = state) do
+    {:stop, :normal, state}
   end
 
   def handle_info(:request_timeout, %{status: :finished} = state), do: {:noreply, state}
@@ -311,12 +319,24 @@ defmodule Jidoka.Chat.RequestController do
     |> finish(result)
   end
 
+  defp finish(%{status: :finished} = state, _result), do: state
+
   defp finish(state, result) do
     cancel_timeout(state)
+    terminate_cancellation_members(state)
     Enum.each(state.awaiters, &GenServer.reply(&1, result))
     Enum.each(state.cancellers, &GenServer.reply(&1, {:error, :request_already_finished}))
+    expiry_ref = make_ref()
+    Process.send_after(self(), {:expire_request, expiry_ref}, state.retention_ms)
 
-    %{state | status: :finished, result: result, awaiters: [], cancellers: []}
+    %{
+      state
+      | status: :finished,
+        result: result,
+        awaiters: [],
+        cancellers: [],
+        expiry_ref: expiry_ref
+    }
   end
 
   defp cancel_timeout(%{timeout_ref: ref}) when is_reference(ref), do: Process.cancel_timer(ref)

--- a/lib/jidoka/chat/request_controller.ex
+++ b/lib/jidoka/chat/request_controller.ex
@@ -37,6 +37,7 @@ defmodule Jidoka.Chat.RequestController do
   catch
     :exit, {:timeout, _call} -> {:error, :timeout}
     :exit, {:noproc, _call} -> {:error, :request_expired}
+    :exit, {:normal, _call} -> {:error, :request_expired}
   end
 
   @spec cancel(pid(), keyword()) :: {:ok, Cancellation.t()} | {:error, term()}
@@ -47,6 +48,7 @@ defmodule Jidoka.Chat.RequestController do
   catch
     :exit, {:timeout, _call} -> {:error, :cancellation_timeout}
     :exit, {:noproc, _call} -> {:error, :request_expired}
+    :exit, {:normal, _call} -> {:error, :request_expired}
   end
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
@@ -85,6 +87,7 @@ defmodule Jidoka.Chat.RequestController do
        status: :running,
        result: nil,
        terminal?: false,
+       pending_terminal: nil,
        cancellation_requested?: false,
        cancellation_forced?: false,
        awaiters: [],
@@ -94,13 +97,14 @@ defmodule Jidoka.Chat.RequestController do
        agent_id: nil,
        timeout_ref: timeout_ref,
        retention_ms: retention_ms,
-       expiry_ref: nil
+       expiry_ref: nil,
+       runtime_ready?: false
      }}
   end
 
   @impl true
   def handle_call(:runtime, _from, state) do
-    {:reply, {:ok, state.task, state.token}, state}
+    {:reply, {:ok, state.task, state.token}, mark_runtime_ready(state)}
   end
 
   def handle_call(:await, _from, %{status: :finished} = state) do
@@ -215,6 +219,7 @@ defmodule Jidoka.Chat.RequestController do
   end
 
   defp accept_event(%{terminal?: true} = state, _event), do: state
+  defp accept_event(%{pending_terminal: %Event{}} = state, _event), do: state
 
   defp accept_event(state, %Event{} = event) do
     case Order.classify(event, state.request_id) do
@@ -234,17 +239,16 @@ defmodule Jidoka.Chat.RequestController do
   end
 
   defp accept_classified_event(state, %Event{} = event) do
-    state = forward_event(state, event)
-
     cond do
       Event.cancelled?(event) ->
+        state = forward_event(state, event)
         %{state | terminal?: true, cancellation_requested?: true}
 
       EventDispatcher.terminal?(event) ->
-        %{state | terminal?: true}
+        %{state | pending_terminal: event}
 
       true ->
-        state
+        forward_event(state, event)
     end
   end
 
@@ -326,17 +330,15 @@ defmodule Jidoka.Chat.RequestController do
     terminate_cancellation_members(state)
     Enum.each(state.awaiters, &GenServer.reply(&1, result))
     Enum.each(state.cancellers, &GenServer.reply(&1, {:error, :request_already_finished}))
-    expiry_ref = make_ref()
-    Process.send_after(self(), {:expire_request, expiry_ref}, state.retention_ms)
 
     %{
       state
       | status: :finished,
         result: result,
         awaiters: [],
-        cancellers: [],
-        expiry_ref: expiry_ref
+        cancellers: []
     }
+    |> maybe_schedule_expiry()
   end
 
   defp cancel_timeout(%{timeout_ref: ref}) when is_reference(ref), do: Process.cancel_timer(ref)
@@ -346,13 +348,31 @@ defmodule Jidoka.Chat.RequestController do
 
   defp ensure_cancellation_terminal(state) do
     state
+    |> Map.put(:pending_terminal, nil)
     |> emit_cancellation_event(state.cancellation_forced?)
     |> Map.put(:terminal?, true)
   end
 
   defp ensure_terminal_for_result(%{terminal?: true} = state, _result), do: state
 
+  defp ensure_terminal_for_result(%{pending_terminal: %Event{} = event} = state, result) do
+    if event.event == terminal_event(result) do
+      state
+      |> Map.put(:pending_terminal, nil)
+      |> forward_event(event)
+      |> Map.put(:terminal?, true)
+    else
+      state
+      |> Map.put(:pending_terminal, nil)
+      |> emit_terminal_for_result(result)
+    end
+  end
+
   defp ensure_terminal_for_result(state, result) do
+    emit_terminal_for_result(state, result)
+  end
+
+  defp emit_terminal_for_result(state, result) do
     event =
       Event.build(terminal_event(result), [],
         seq: state.next_seq,
@@ -365,6 +385,20 @@ defmodule Jidoka.Chat.RequestController do
     |> forward_event(event)
     |> Map.put(:terminal?, true)
   end
+
+  defp mark_runtime_ready(state) do
+    state
+    |> Map.put(:runtime_ready?, true)
+    |> maybe_schedule_expiry()
+  end
+
+  defp maybe_schedule_expiry(%{status: :finished, runtime_ready?: true, expiry_ref: nil} = state) do
+    expiry_ref = make_ref()
+    Process.send_after(self(), {:expire_request, expiry_ref}, state.retention_ms)
+    %{state | expiry_ref: expiry_ref}
+  end
+
+  defp maybe_schedule_expiry(state), do: state
 
   defp terminal_event({:ok, _result}), do: :turn_finished
   defp terminal_event({:hibernate, _snapshot}), do: :turn_hibernated

--- a/lib/jidoka/session/sequence/request_controller.ex
+++ b/lib/jidoka/session/sequence/request_controller.ex
@@ -37,6 +37,7 @@ defmodule Jidoka.Session.Sequence.RequestController do
   catch
     :exit, {:timeout, _call} -> {:error, :timeout}
     :exit, {:noproc, _call} -> {:error, :request_expired}
+    :exit, {:normal, _call} -> {:error, :request_expired}
   end
 
   @doc false
@@ -48,6 +49,7 @@ defmodule Jidoka.Session.Sequence.RequestController do
   catch
     :exit, {:timeout, _call} -> {:error, :cancellation_timeout}
     :exit, {:noproc, _call} -> {:error, :request_expired}
+    :exit, {:normal, _call} -> {:error, :request_expired}
   end
 
   @doc false

--- a/lib/jidoka/session/sequence/request_controller.ex
+++ b/lib/jidoka/session/sequence/request_controller.ex
@@ -13,6 +13,7 @@ defmodule Jidoka.Session.Sequence.RequestController do
   @task_supervisor Jidoka.Session.Sequence.TaskSupervisor
   @request_supervisor Jidoka.Session.Sequence.RequestSupervisor
   @default_grace_ms 100
+  @default_retention_ms 30_000
 
   @type start_opts :: [
           request_id: String.t(),
@@ -62,6 +63,7 @@ defmodule Jidoka.Session.Sequence.RequestController do
     session = Keyword.fetch!(opts, :session)
     request_inputs = Keyword.fetch!(opts, :request_inputs)
     runtime_opts = Keyword.fetch!(opts, :runtime_opts)
+    retention_ms = positive_integer(Keyword.get(runtime_opts, :request_retention_ms), @default_retention_ms)
     token = Token.new()
     controller = self()
 
@@ -95,7 +97,9 @@ defmodule Jidoka.Session.Sequence.RequestController do
        awaiters: [],
        cancellers: [],
        cancellation_members: %{},
-       progress: %{session: session, steps: [], index: 1, request: nil}
+       progress: %{session: session, steps: [], index: 1, request: nil},
+       retention_ms: retention_ms,
+       expiry_ref: nil
      }}
   end
 
@@ -169,6 +173,10 @@ defmodule Jidoka.Session.Sequence.RequestController do
     monitor_ref = Process.monitor(pid)
 
     {:noreply, %{state | cancellation_members: Map.put(state.cancellation_members, pid, monitor_ref)}}
+  end
+
+  def handle_info({:expire_request, expiry_ref}, %{status: :finished, expiry_ref: expiry_ref} = state) do
+    {:stop, :normal, state}
   end
 
   def handle_info({:force_cancel, _ref}, %{status: :finished} = state), do: {:noreply, state}
@@ -326,9 +334,15 @@ defmodule Jidoka.Session.Sequence.RequestController do
   defp request_id(%Turn.Request{request_id: request_id}), do: request_id
   defp request_id(_request), do: nil
 
+  defp finish(%{status: :finished} = state, _result), do: state
+
   defp finish(state, result) do
+    terminate_cancellation_members(state)
     Enum.each(state.awaiters, &GenServer.reply(&1, result))
-    %{state | status: :finished, result: result, awaiters: []}
+    expiry_ref = make_ref()
+    Process.send_after(self(), {:expire_request, expiry_ref}, state.retention_ms)
+
+    %{state | status: :finished, result: result, awaiters: [], expiry_ref: expiry_ref}
   end
 
   defp positive_integer(value, _default) when is_integer(value) and value > 0, do: value

--- a/test/jidoka/request_controller_cleanup_test.exs
+++ b/test/jidoka/request_controller_cleanup_test.exs
@@ -40,6 +40,53 @@ defmodule Jidoka.RequestControllerCleanupTest do
     assert {:error, :request_expired} = Jidoka.cancel(request)
   end
 
+  test "a terminal event waits for the matching worker result" do
+    parent = self()
+
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :cleanup_target,
+               "Defer terminal",
+               [
+                 stream: true,
+                 request_id: "cleanup-terminal-result",
+                 request_timeout_ms: 100
+               ],
+               fn opts ->
+                 :ok =
+                   Jidoka.Stream.emit(
+                     Event.build(:turn_finished, [], request_id: "cleanup-terminal-result"),
+                     opts
+                   )
+
+                 send(parent, :terminal_candidate_sent)
+                 Process.sleep(:infinity)
+               end
+             )
+
+    assert_receive :terminal_candidate_sent, 1_000
+    refute_receive {:jidoka_turn_event, %Event{event: :turn_finished}}, 20
+
+    assert {:error, :request_timeout} = Jidoka.await(request, timeout: 1_000)
+    assert_receive {:jidoka_turn_event, %Event{event: :turn_failed} = event}, 1_000
+    assert event.data.reason == inspect(:request_timeout)
+    refute_receive {:jidoka_turn_event, %Event{event: :turn_finished}}, 20
+  end
+
+  test "small retention cannot expire a chat controller before its startup handshake" do
+    for index <- 1..25 do
+      assert {:ok, request} =
+               Jidoka.Chat.Async.start_fun(
+                 :cleanup_target,
+                 "Fast completion",
+                 [request_id: "cleanup-startup-#{index}", request_retention_ms: 1],
+                 fn _opts -> {:ok, index} end
+               )
+
+      assert request.request_id == "cleanup-startup-#{index}"
+    end
+  end
+
   test "error, timeout, and worker-exit controllers expire within the same bound" do
     for {name, fun, expected} <- [
           {:rejection, fn _opts -> {:error, :policy_denied} end, {:error, :policy_denied}},

--- a/test/jidoka/request_controller_cleanup_test.exs
+++ b/test/jidoka/request_controller_cleanup_test.exs
@@ -1,0 +1,151 @@
+defmodule Jidoka.RequestControllerCleanupTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.Agent
+  alias Jidoka.Cancellation.Token
+  alias Jidoka.Event
+  alias Jidoka.Event.Order
+  alias Jidoka.Session
+  alias Jidoka.Session.Sequence
+  alias Jidoka.Session.Sequence.Request, as: SequenceRequest
+  alias Jidoka.Turn
+
+  test "a completed chat controller expires and stops registered members" do
+    parent = self()
+    member = spawn(fn -> Process.sleep(:infinity) end)
+    member_monitor = Process.monitor(member)
+    on_exit(fn -> if Process.alive?(member), do: Process.exit(member, :kill) end)
+
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :cleanup_target,
+               "Complete",
+               [request_id: "cleanup-complete", request_retention_ms: 10],
+               fn opts ->
+                 :ok = Token.register(Keyword.fetch!(opts, :cancellation), member)
+                 send(parent, {:registered_member, member})
+                 {:ok, "done"}
+               end
+             )
+
+    controller_monitor = Process.monitor(request.controller)
+    assert_receive {:registered_member, ^member}, 1_000
+    assert {:ok, "done"} = Jidoka.await(request, timeout: 1_000)
+    assert {:ok, "done"} = Jidoka.await(request, timeout: 100)
+    assert {:error, :request_already_finished} = Jidoka.cancel(request)
+
+    assert_receive {:DOWN, ^member_monitor, :process, ^member, :killed}, 1_000
+    assert_receive {:DOWN, ^controller_monitor, :process, _pid, :normal}, 1_000
+    assert {:error, :request_expired} = Jidoka.await(request)
+    assert {:error, :request_expired} = Jidoka.cancel(request)
+  end
+
+  test "error, timeout, and worker-exit controllers expire within the same bound" do
+    for {name, fun, expected} <- [
+          {:rejection, fn _opts -> {:error, :policy_denied} end, {:error, :policy_denied}},
+          {:worker_exit, fn _opts -> raise "worker failed" end, :worker_exit},
+          {:timeout, fn _opts -> Process.sleep(:infinity) end, {:error, :request_timeout}}
+        ] do
+      opts = [request_id: "cleanup-#{name}", request_retention_ms: 10]
+      opts = if name == :timeout, do: Keyword.put(opts, :request_timeout_ms, 15), else: opts
+
+      assert {:ok, request} =
+               Jidoka.Chat.Async.start_fun(:cleanup_target, "Stop", opts, fun)
+
+      monitor = Process.monitor(request.controller)
+      result = Jidoka.await(request, timeout: 1_000)
+
+      case expected do
+        :worker_exit -> assert {:error, {:chat_request_failed, _reason}} = result
+        expected_result -> assert result == expected_result
+      end
+
+      assert_receive {:DOWN, ^monitor, :process, _pid, :normal}, 1_000
+    end
+  end
+
+  test "forced cancellation stops the worker and expires the controller" do
+    parent = self()
+
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :cleanup_cancel,
+               "Cancel",
+               [request_id: "cleanup-cancel", request_retention_ms: 10, stream: true],
+               fn _opts ->
+                 send(parent, {:cleanup_worker, self()})
+                 Process.sleep(:infinity)
+               end
+             )
+
+    assert_receive {:cleanup_worker, worker}, 1_000
+    worker_monitor = Process.monitor(worker)
+    controller_monitor = Process.monitor(request.controller)
+    stream = Jidoka.stream(request, stream_event_timeout_ms: 200)
+
+    assert {:ok, _cancellation} = Jidoka.cancel(request, grace_ms: 5)
+    assert {:cancelled, _cancellation} = Jidoka.await(request, timeout: 100)
+    events = Enum.to_list(stream)
+    assert Enum.count(events, &Order.terminal?/1) == 1
+
+    assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
+    assert_receive {:DOWN, ^controller_monitor, :process, _pid, :normal}, 1_000
+  end
+
+  test "owner exit stops the controller without leaving a live handle" do
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        assert {:ok, request} =
+                 Jidoka.Chat.Async.start_fun(
+                   :cleanup_owner,
+                   "Owner",
+                   [request_id: "cleanup-owner", stream_to: parent],
+                   fn _opts -> Process.sleep(:infinity) end
+                 )
+
+        send(parent, {:owned, request})
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:owned, request}, 1_000
+    monitor = Process.monitor(request.controller)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^monitor, :process, _pid, :normal}, 1_000
+    assert_receive {:jidoka_turn_event, %Event{} = event}, 1_000
+    assert Order.terminal?(event)
+    refute_receive {:jidoka_turn_event, %Event{event: :turn_failed}}, 50
+    assert {:error, :request_expired} = Jidoka.await(request)
+  end
+
+  test "a completed sequence controller also expires" do
+    assert {:ok, session} = Session.start(spec(), "cleanup-sequence")
+
+    assert {:ok, request} =
+             Session.run_sequence_async(
+               session,
+               [Turn.Request.new!(input: "Complete", request_id: "cleanup-sequence-turn")],
+               sequence_request_id: "cleanup-sequence-request",
+               request_retention_ms: 10,
+               llm: fn _intent, _journal, _context ->
+                 {:ok, %{type: :final, content: "done"}}
+               end
+             )
+
+    assert {:ok, controller} = SequenceRequest.controller(request)
+    monitor = Process.monitor(controller)
+    assert {:ok, %Sequence.Result{status: :completed}} = Jidoka.await(request, timeout: 1_000)
+    assert {:ok, %Sequence.Result{status: :completed}} = Jidoka.await(request, timeout: 100)
+    assert_receive {:DOWN, ^monitor, :process, ^controller, :normal}, 1_000
+    assert {:error, :request_expired} = Jidoka.await(request)
+  end
+
+  defp spec do
+    Agent.Spec.new!(
+      id: "cleanup_agent",
+      instructions: "Complete the bounded cleanup test.",
+      model: %{provider: :test, id: "model"}
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- Stops chat and session-sequence request controllers after a bounded retention window.
- Completion, error, cancellation, timeout, and owner exit leave no live controller.
- Completed handles return the documented result and do not restart work.
- Expired handles return `:request_expired`.
- A cleanup race cannot create a second terminal event or a second live controller.

This is the Jidoka side of Jido Console Milestone 2 epic M2-E02 (`jido_console-m2e02`). It is stacked on #56.

## Test plan

- [x] `mix test test/jidoka/request_controller_cleanup_test.exs test/jidoka/event_order_test.exs`
- [ ] CI green