### PR TITLE
feat(projection): add the portable request-stream facade

### DIFF
--- a/lib/jidoka.ex
+++ b/lib/jidoka.ex
@@ -23,7 +23,8 @@ defmodule Jidoka do
   * `resume/2` continues from a hibernated snapshot;
   * `pending_reviews/1`, `approve/3`, and `deny/3` cover common approval flows;
   * `export/2` writes portable JSON/YAML agent data;
-  * `inspect/2`, `preflight/3`, and `project/1` expose debugging views.
+  * `inspect/2`, `preflight/3`, `project/1`, and `project_events/1` expose
+    debugging views and the portable request-stream projection.
   """
 
   alias Jidoka.Agent
@@ -448,10 +449,23 @@ defmodule Jidoka do
 
   `project/1` is the data-facing companion to `inspect/2`. It returns compact,
   deterministic maps that are useful for tests, golden files, traces, and UI
-  rendering.
+  rendering. For an ordered request stream, prefer `project_events/1`.
   """
   @spec project(term()) :: term()
   def project(value), do: Jidoka.Projection.project(value)
+
+  @doc """
+  Projects one ordered request stream into portable Console-facing maps.
+
+  This is the documented root facade for Jido Console. Each record keeps the
+  request, turn, and event identities, redacts sensitive values, enforces
+  size bounds, and drops PIDs, references, functions, and private runtime
+  structs. The result is JSON-compatible.
+  """
+  @spec project_events([Jidoka.Event.t()] | Jidoka.Event.t()) ::
+          {:ok, [map()]} | {:ok, map()} | {:error, term()}
+  def project_events(%Jidoka.Event{} = event), do: Jidoka.Projection.Stream.project(event)
+  def project_events(events) when is_list(events), do: Jidoka.Projection.Stream.project_events(events)
 
   @doc """
   Normalizes any error term into a Splode-backed `Jidoka.Error` exception.

--- a/lib/jidoka/projection/stream.ex
+++ b/lib/jidoka/projection/stream.ex
@@ -1,0 +1,182 @@
+defmodule Jidoka.Projection.Stream do
+  @moduledoc """
+  Portable, redacted, bounded projection for one ordered request stream.
+
+  This module is an implementation detail of `Jidoka.project_events/2`. Hosts
+  should call the root facade, not this module.
+  """
+
+  alias Jidoka.Event
+  alias Jidoka.Event.Order
+  alias Jidoka.Portable
+
+  @max_unknown_bytes 4_096
+  @max_data_bytes 65_536
+
+  @type projection :: %{
+          required(:request_id) => String.t(),
+          required(:seq) => non_neg_integer(),
+          required(:event) => String.t(),
+          required(:terminal?) => boolean(),
+          optional(:agent_id) => String.t(),
+          optional(:turn_id) => String.t(),
+          optional(:effect_id) => String.t(),
+          optional(:loop_index) => non_neg_integer(),
+          optional(:status) => String.t(),
+          optional(:category) => String.t(),
+          optional(:phase) => String.t(),
+          optional(:data) => map(),
+          optional(:error) => term(),
+          optional(:unknown) => map()
+        }
+
+  @doc "Projects one event through the portable request-stream contract."
+  @spec project(Event.t() | term()) :: {:ok, projection()} | {:error, term()}
+  def project(%Event{} = event) do
+    with :ok <- require_request(event),
+         {:ok, data} <- project_data(event.data) do
+      {:ok,
+       %{
+         request_id: event.request_id,
+         seq: event.seq,
+         event: Atom.to_string(event.event),
+         terminal?: Order.terminal?(event)
+       }
+       |> maybe_put(:agent_id, event.agent_id)
+       |> maybe_put(:turn_id, turn_id(event))
+       |> maybe_put(:effect_id, event.effect_id)
+       |> maybe_put(:loop_index, event.loop_index)
+       |> maybe_put(:status, stringify(event.status))
+       |> maybe_put(:category, stringify(event.category))
+       |> maybe_put(:phase, stringify(event.phase))
+       |> maybe_put(:data, data)
+       |> maybe_put(:error, project_error(event.error))}
+    end
+  end
+
+  def project(value), do: {:error, {:unsupported_projection, value}}
+
+  @doc "Projects an ordered event list."
+  @spec project_events([Event.t()]) :: {:ok, [projection()]} | {:error, term()}
+  def project_events(events) when is_list(events) do
+    events
+    |> Enum.reduce_while({:ok, []}, fn event, {:ok, acc} ->
+      case project(event) do
+        {:ok, projected} -> {:cont, {:ok, [projected | acc]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, projected} -> {:ok, Enum.reverse(projected)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp require_request(%Event{request_id: request_id}) when is_binary(request_id), do: :ok
+  defp require_request(%Event{}), do: {:error, :missing_request_id}
+
+  defp project_data(data) when data in [nil, %{}], do: {:ok, nil}
+
+  defp project_data(data) when is_map(data) do
+    projected = data |> Portable.project() |> drop_runtime() |> stringify_keys()
+
+    cond do
+      encoded_size(projected) > @max_data_bytes ->
+        {:error, :projection_too_large}
+
+      true ->
+        {known, unknown} = split_unknown(projected)
+
+        if encoded_size(unknown) > @max_unknown_bytes do
+          {:error, :unknown_projection_overflow}
+        else
+          {:ok, maybe_put(known, "unknown", empty_to_nil(unknown))}
+        end
+    end
+  end
+
+  defp project_data(data), do: {:ok, drop_runtime(Portable.project(data))}
+
+  defp project_error(nil), do: nil
+
+  defp project_error(error) do
+    error
+    |> Portable.project()
+    |> drop_runtime()
+    |> stringify_keys()
+    |> json_safe()
+  end
+
+  defp json_safe(value) when is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value), do: value
+  defp json_safe(value) when is_atom(value), do: Atom.to_string(value)
+  defp json_safe(value) when is_list(value), do: Enum.map(value, &json_safe/1)
+  defp json_safe(value) when is_map(value), do: Map.new(value, fn {key, item} -> {stringify(key), json_safe(item)} end)
+  defp json_safe(value), do: inspect(value)
+
+  defp drop_runtime(value) when is_pid(value) or is_reference(value) or is_function(value) or is_port(value) do
+    nil
+  end
+
+  defp drop_runtime(%module{} = struct) do
+    if json_safe_struct?(module) do
+      struct
+    else
+      struct |> Map.from_struct() |> drop_runtime()
+    end
+  end
+
+  defp drop_runtime(value) when is_map(value) do
+    value
+    |> Enum.reduce(%{}, fn {key, item}, acc ->
+      case drop_runtime(item) do
+        nil -> acc
+        projected -> Map.put(acc, key, projected)
+      end
+    end)
+  end
+
+  defp drop_runtime(value) when is_list(value), do: Enum.map(value, &drop_runtime/1)
+  defp drop_runtime(value), do: value
+
+  defp stringify_keys(value) when is_map(value) do
+    Map.new(value, fn {key, item} -> {stringify(key), stringify_keys(item)} end)
+  end
+
+  defp stringify_keys(value) when is_list(value), do: Enum.map(value, &stringify_keys/1)
+  defp stringify_keys(value) when is_atom(value) and value not in [nil, true, false], do: Atom.to_string(value)
+  defp stringify_keys(value), do: value
+
+  defp split_unknown(data) do
+    Enum.split_with(data, fn {key, _value} -> known_data_key?(key) end)
+    |> then(fn {known, unknown} -> {Map.new(known), Map.new(unknown)} end)
+  end
+
+  defp known_data_key?(key) when key in ~w(reason forced content text operation turn_id token), do: true
+  defp known_data_key?(_key), do: false
+
+  defp turn_id(%Event{data: %{turn_id: turn_id}}) when is_binary(turn_id), do: turn_id
+  defp turn_id(%Event{data: %{"turn_id" => turn_id}}) when is_binary(turn_id), do: turn_id
+  defp turn_id(%Event{}), do: nil
+
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify(value), do: value
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, %{} = value) when map_size(value) == 0, do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp empty_to_nil(value) when value == %{}, do: nil
+  defp empty_to_nil(value), do: value
+
+  defp json_safe_struct?(module) do
+    module in [Date, Time, DateTime, NaiveDateTime]
+  end
+
+  defp encoded_size(value) do
+    case Jason.encode(value) do
+      {:ok, json} -> byte_size(json)
+      {:error, _reason} -> @max_data_bytes + 1
+    end
+  end
+end

--- a/lib/jidoka/projection/stream.ex
+++ b/lib/jidoka/projection/stream.ex
@@ -2,7 +2,7 @@ defmodule Jidoka.Projection.Stream do
   @moduledoc """
   Portable, redacted, bounded projection for one ordered request stream.
 
-  This module is an implementation detail of `Jidoka.project_events/2`. Hosts
+  This module is an implementation detail of `Jidoka.project_events/1`. Hosts
   should call the root facade, not this module.
   """
 
@@ -21,6 +21,8 @@ defmodule Jidoka.Projection.Stream do
           optional(:agent_id) => String.t(),
           optional(:turn_id) => String.t(),
           optional(:effect_id) => String.t(),
+          optional(:effect_kind) => String.t(),
+          optional(:operation) => String.t(),
           optional(:loop_index) => non_neg_integer(),
           optional(:status) => String.t(),
           optional(:category) => String.t(),
@@ -35,22 +37,26 @@ defmodule Jidoka.Projection.Stream do
   def project(%Event{} = event) do
     with :ok <- require_request(event),
          {:ok, data} <- project_data(event.data) do
-      {:ok,
-       %{
-         request_id: event.request_id,
-         seq: event.seq,
-         event: Atom.to_string(event.event),
-         terminal?: Order.terminal?(event)
-       }
-       |> maybe_put(:agent_id, event.agent_id)
-       |> maybe_put(:turn_id, turn_id(event))
-       |> maybe_put(:effect_id, event.effect_id)
-       |> maybe_put(:loop_index, event.loop_index)
-       |> maybe_put(:status, stringify(event.status))
-       |> maybe_put(:category, stringify(event.category))
-       |> maybe_put(:phase, stringify(event.phase))
-       |> maybe_put(:data, data)
-       |> maybe_put(:error, project_error(event.error))}
+      projection =
+        %{
+          request_id: event.request_id,
+          seq: event.seq,
+          event: Atom.to_string(event.event),
+          terminal?: Order.terminal?(event)
+        }
+        |> maybe_put(:agent_id, event.agent_id)
+        |> maybe_put(:turn_id, turn_id(event))
+        |> maybe_put(:effect_id, event.effect_id)
+        |> maybe_put(:effect_kind, stringify(event.effect_kind))
+        |> maybe_put(:operation, event.operation)
+        |> maybe_put(:loop_index, event.loop_index)
+        |> maybe_put(:status, stringify(event.status))
+        |> maybe_put(:category, stringify(event.category))
+        |> maybe_put(:phase, stringify(event.phase))
+        |> maybe_put(:data, data)
+        |> maybe_put(:error, project_error(event.error))
+
+      require_bounded_projection(projection)
     end
   end
 
@@ -151,7 +157,13 @@ defmodule Jidoka.Projection.Stream do
     |> then(fn {known, unknown} -> {Map.new(known), Map.new(unknown)} end)
   end
 
-  defp known_data_key?(key) when key in ~w(reason forced content text operation turn_id token), do: true
+  defp known_data_key?(key)
+       when key in ~w(
+              reason forced content text operation turn_id token
+              type delta chunk_type call usage warning finish_reason error
+            ),
+       do: true
+
   defp known_data_key?(_key), do: false
 
   defp turn_id(%Event{data: %{turn_id: turn_id}}) when is_binary(turn_id), do: turn_id
@@ -171,6 +183,12 @@ defmodule Jidoka.Projection.Stream do
 
   defp json_safe_struct?(module) do
     module in [Date, Time, DateTime, NaiveDateTime]
+  end
+
+  defp require_bounded_projection(projection) do
+    if encoded_size(projection) <= @max_data_bytes,
+      do: {:ok, projection},
+      else: {:error, :projection_too_large}
   end
 
   defp encoded_size(value) do

--- a/test/jidoka/projection_stream_test.exs
+++ b/test/jidoka/projection_stream_test.exs
@@ -56,6 +56,50 @@ defmodule Jidoka.ProjectionStreamTest do
     assert {:error, :unknown_projection_overflow} = Jidoka.project_events(event)
   end
 
+  test "operation identity is kept in projected events" do
+    event =
+      Event.build(:effect_completed, [],
+        request_id: "req-operation",
+        seq: 0,
+        effect_id: "effect-1",
+        effect_kind: :operation,
+        operation: "search"
+      )
+
+    assert {:ok, projected} = Jidoka.project_events(event)
+    assert projected.effect_id == "effect-1"
+    assert projected.effect_kind == "operation"
+    assert projected.operation == "search"
+  end
+
+  test "canonical LLM delta fields use the normal data bound" do
+    delta = String.duplicate("x", 5_000)
+
+    event =
+      Event.build(:llm_delta, [],
+        request_id: "req-delta",
+        seq: 0,
+        data: %{type: :text_delta, delta: delta, chunk_type: :content}
+      )
+
+    assert {:ok, projected} = Jidoka.project_events(event)
+    assert projected.data["type"] == "text_delta"
+    assert projected.data["delta"] == delta
+    assert projected.data["chunk_type"] == "content"
+    refute Map.has_key?(projected.data, "unknown")
+  end
+
+  test "oversized errors are rejected" do
+    event =
+      Event.build(:turn_failed, [],
+        request_id: "req-error",
+        seq: 0,
+        error: %{message: String.duplicate("x", 70_000)}
+      )
+
+    assert {:error, :projection_too_large} = Jidoka.project_events(event)
+  end
+
   test "events without a request identity are rejected" do
     event = Event.build(:turn_started, [], seq: 0)
     assert {:error, :missing_request_id} = Jidoka.project_events([event])

--- a/test/jidoka/projection_stream_test.exs
+++ b/test/jidoka/projection_stream_test.exs
@@ -1,0 +1,63 @@
+defmodule Jidoka.ProjectionStreamTest do
+  use ExUnit.Case, async: true
+
+  alias Jidoka.Event
+
+  test "the root facade projects known, terminal, error, and unknown event data" do
+    events = [
+      Event.build(:turn_started, [], request_id: "req-1", seq: 0, agent_id: "agent-1", data: %{turn_id: "trn-1"}),
+      Event.build(:llm_delta, [], request_id: "req-1", seq: 1, data: %{text: "Hello", extra: "bounded"}),
+      Event.build(:turn_failed, [], request_id: "req-1", seq: 2, error: {:boom, :policy_denied})
+    ]
+
+    assert {:ok, projected} = Jidoka.project_events(events)
+    assert Enum.map(projected, & &1.seq) == [0, 1, 2]
+    assert Enum.map(projected, & &1.request_id) == ["req-1", "req-1", "req-1"]
+    assert hd(projected).turn_id == "trn-1"
+    assert hd(projected).agent_id == "agent-1"
+    assert List.last(projected).terminal? == true
+    assert Enum.at(projected, 1).data["text"] == "Hello"
+    assert Enum.at(projected, 1).data["unknown"]["extra"] == "bounded"
+    assert {:ok, _} = Jason.encode(projected)
+  end
+
+  test "sensitive values are redacted and runtime values do not cross the facade" do
+    event =
+      Event.build(:effect_completed, [],
+        request_id: "req-2",
+        seq: 0,
+        data: %{
+          token: "sk-secret",
+          owner: self(),
+          ref: make_ref(),
+          fun: fn -> :ok end
+        }
+      )
+
+    assert {:ok, projected} = Jidoka.project_events(event)
+    encoded = inspect(projected)
+    refute encoded =~ "sk-secret"
+    refute encoded =~ "#PID"
+    refute encoded =~ "#Reference"
+    assert projected.data["token"] == "[REDACTED]"
+    refute Map.has_key?(projected.data, "owner")
+    refute Map.has_key?(projected.data, "fun")
+    assert {:ok, _} = Jason.encode(projected)
+  end
+
+  test "oversized unknown data is rejected" do
+    event =
+      Event.build(:llm_delta, [],
+        request_id: "req-3",
+        seq: 0,
+        data: %{blob: String.duplicate("x", 5_000)}
+      )
+
+    assert {:error, :unknown_projection_overflow} = Jidoka.project_events(event)
+  end
+
+  test "events without a request identity are rejected" do
+    event = Event.build(:turn_started, [], seq: 0)
+    assert {:error, :missing_request_id} = Jidoka.project_events([event])
+  end
+end

--- a/test/jidoka/stabilization_contract_test.exs
+++ b/test/jidoka/stabilization_contract_test.exs
@@ -112,6 +112,7 @@ defmodule Jidoka.StabilizationContractTest do
       preflight: 2,
       preflight: 3,
       project: 1,
+      project_events: 1,
       recover_session: 1,
       recover_session: 2,
       reset_handoff: 1,


### PR DESCRIPTION
## Summary

- Adds `Jidoka.project_events/1` as the documented root facade for Console.
- Projection records keep request, turn, and event identities.
- Output is JSON-compatible, redacted, and size-bounded.
- PIDs, references, functions, and private runtime structs do not cross the facade.

This is the Jidoka side of Jido Console Milestone 2 epic M2-E05 (`jido_console-m2e05`). It is stacked on #57.

## Test plan

- [x] `mix test test/jidoka/projection_stream_test.exs`
- [ ] CI green