### PR TITLE
fix(events): treat session chat success as a finished stream

### DIFF
--- a/lib/jidoka/chat/request_controller.ex
+++ b/lib/jidoka/chat/request_controller.ex
@@ -401,6 +401,7 @@ defmodule Jidoka.Chat.RequestController do
   defp maybe_schedule_expiry(state), do: state
 
   defp terminal_event({:ok, _result}), do: :turn_finished
+  defp terminal_event({:ok, _session, _text}), do: :turn_finished
   defp terminal_event({:hibernate, _snapshot}), do: :turn_hibernated
   defp terminal_event({:hibernate, _session, _snapshot}), do: :turn_hibernated
   defp terminal_event(_result), do: :turn_failed

--- a/test/jidoka/event_order_test.exs
+++ b/test/jidoka/event_order_test.exs
@@ -63,6 +63,22 @@ defmodule Jidoka.EventOrderTest do
     assert Enum.count(events, &Order.terminal?/1) == 1
   end
 
+  test "a session-shaped success tuple still emits turn_finished" do
+    assert {:ok, request} =
+             Jidoka.Chat.Async.start_fun(
+               :ordered_target,
+               "Session shape",
+               [stream: true, request_id: "controller-session-ok"],
+               fn _opts -> {:ok, %{id: "ses_1"}, "done"} end
+             )
+
+    stream = Jidoka.stream(request, stream_event_timeout_ms: 100)
+    assert {:ok, %{id: "ses_1"}, "done"} = Jidoka.await(request, timeout: 1_000)
+    events = Enum.to_list(stream)
+    assert List.last(events).event == :turn_finished
+    assert :ok = Order.validate(events)
+  end
+
   test "foreign and late events cannot create a second terminal result" do
     parent = self()
 


### PR DESCRIPTION
## Summary

Caller-managed session chats return `{:ok, session, text}`. The request controller only treated `{:ok, result}` as finished, so a successful session stream ended in `:turn_failed`.

This makes the 3-tuple success shape emit `:turn_finished`.

Needed by agentjido/jido_console#8 (`Runtime.Jidoka` session tests).

## Test plan

- [x] `mix test test/jidoka/event_order_test.exs`
- [ ] CI