### PR TITLE
feat(session): qualify durable store contract

### DIFF
--- a/guides/runtime-capabilities-internals.md
+++ b/guides/runtime-capabilities-internals.md
@@ -314,7 +314,8 @@ durable form of `Turn.State` plus a cursor. Three details matter to
 contributors:
 
 - **Schema version is part of the snapshot.**
-  `Jidoka.Snapshot.schema_version/0` returns `1`. Bumping it
+  `Jidoka.Snapshot.schema_version/0` returns `2`, and
+  `supported_schema_versions/0` returns `[1, 2]`. Bumping the current version
   requires migration logic in `from_input/1`.
 - **Serialize is opaque.** `serialize/1` produces a string with the prefix
   `"jidoka:snapshot:v1:"` followed by base64-encoded `:erlang.term_to_binary`.

--- a/guides/sessions-and-stores.md
+++ b/guides/sessions-and-stores.md
@@ -91,7 +91,8 @@ session data between turns.
 - [`Jidoka.Session`](`Jidoka.Session`) is the developer-facing facade. It
   wraps `start/run/chat/resume` and derives sensible defaults.
 - [`Jidoka.Session.Data`](`Jidoka.Session.Data`) is the durable data
-  struct. Its `schema_version/0` is `1`; older or newer payloads fail at
+  struct. Its `schema_version/0` is `3`, and
+  `supported_schema_versions/0` is `[1, 2, 3]`. Future payloads fail at
   normalization rather than silently loading a half-valid session.
 - [`Jidoka.Session.Store`](`Jidoka.Session.Store`) is the persistence
   behaviour. Its base callbacks store and read session data. Lease-aware
@@ -103,7 +104,7 @@ pending reviews, the latest result, and typed cancellation evidence.
 
 The session schema version is the serialized-data contract. It is not a turn
 counter. Conversation `turn_count` and `continuation_revision` can increase
-while `schema_version` stays at `1`.
+while `schema_version` stays at `3`.
 
 ## How To
 
@@ -412,9 +413,25 @@ transitions:
 - `renew_session/3` to extend ownership;
 - `commit_session/4` to save final state and release ownership.
 
-Use the helpers in `Jidoka.Session.Store` to apply the standard transition
-rules. A backend transaction, row lock, compare-and-set, or single-owner
-process must make each transition atomic.
+A custom store calls the matching public function in
+`Jidoka.Session.Transitions` while it owns the backend transaction. It writes
+the returned session and makes the transaction durable before it returns
+`{:ok, committed_session}`. After a checkpoint, form the host link from the
+committed result:
+
+```elixir
+{:ok, committed_session} =
+  Jidoka.Session.Transitions.checkpoint(current, lease_id, snapshot, opts)
+
+:ok = MyApp.Repo.write_and_commit(committed_session)
+
+{:ok, identity} =
+  Jidoka.Session.Store.checkpoint_identity(committed_session, snapshot)
+```
+
+The identity contains `session_id`, `durable_revision`, `request_id`,
+`lease_id`, and `snapshot_id`. Do not form it from a terminal session after
+`commit_session/4` clears the lease.
 
 Callers reference a store as either `Module` or `{Module, opts}`. The
 in-memory store is `{Jidoka.Session.Store.InMemory, pid: pid}` so the same
@@ -492,7 +509,7 @@ twice concurrently against the same id and assert one call returns
 | `{:error, {:session_already_running, id}}` | Two callers tried to run the same session at the same time. | Serialize callers; if this is expected, retry after the prior call returns. |
 | `{:error, {:missing_session_snapshot, id}}` | Resume was called on a session that never hibernated. | Run a new turn instead, or hibernate explicitly with a checkpoint policy. |
 | `{:error, {:conflicting_session_ids, _, _}}` | Both `:id` and `:session_id` were passed with different values. | Pass only `:session_id`, or make them equal. |
-| `{:error, {:unsupported_session_schema_version, _, 1}}` | A persisted payload predates the current schema. | Migrate the row to schema version 1 or discard it. |
+| `{:error, {:unsupported_session_schema_version, _, 3}}` | A persisted payload has an unsupported schema. | Migrate it to a supported version or reject it without mutation. |
 
 ## Reference
 
@@ -501,7 +518,7 @@ Key modules touched in this guide:
 - [`Jidoka.Session`](`Jidoka.Session`) - public facade for `start/2`,
   `run/3`, `chat/3`, `resume/2`, `pending_reviews/1`, `replay/1`.
 - [`Jidoka.Session.Data`](`Jidoka.Session.Data`) - durable session
-  struct with `schema_version/0 == 1`.
+  struct with `schema_version/0 == 3` and supported versions `[1, 2, 3]`.
 - [`Jidoka.Session.Store`](`Jidoka.Session.Store`) - persistence behaviour.
 - [`Jidoka.Session.Store.InMemory`](`Jidoka.Session.Store.InMemory`) -
   reference store for tests and examples.

--- a/lib/jidoka/session/store.ex
+++ b/lib/jidoka/session/store.ex
@@ -5,15 +5,34 @@ defmodule Jidoka.Session.Store do
   Store implementations persist `Jidoka.Session.Data` values. Lease-aware
   stores also provide atomic claim, checkpoint, commit, renewal, and recovery
   transitions. Runtime clients and provider credentials never enter the store.
+
+  A custom durable store must implement the complete durable callback set. It
+  applies the public functions in `Jidoka.Session.Transitions` inside its own
+  transaction and sends a successful reply only after that transaction is
+  durable. `durable_mode/1` rejects a partial implementation before work can
+  be claimed.
+
+  After a checkpoint commits, `checkpoint_identity/2` returns the stable,
+  portable identity that a host can join to its own durable records. The host
+  must form this value from the committed session returned by the store. It
+  must not reconstruct a lease after a terminal commit clears it.
   """
 
   alias Jidoka.Session.Data
+  alias Jidoka.Session.Lease
   alias Jidoka.Session.Transitions
   alias Jidoka.Snapshot
   alias Jidoka.Turn
 
   @type store :: module() | {module(), keyword()}
   @type durable_mode :: :none | :durable
+  @type checkpoint_identity :: %{
+          session_id: String.t(),
+          durable_revision: non_neg_integer(),
+          request_id: String.t(),
+          lease_id: String.t(),
+          snapshot_id: String.t()
+        }
 
   @durable_callbacks [
     claim_session: 3,
@@ -106,6 +125,43 @@ defmodule Jidoka.Session.Store do
   def list_sessions(store) do
     {module, opts} = normalize_store(store)
     module.list_sessions(opts)
+  end
+
+  @doc "Returns the stable identity of one committed durable checkpoint."
+  @spec checkpoint_identity(Data.t(), Snapshot.t()) ::
+          {:ok, checkpoint_identity()} | {:error, term()}
+  def checkpoint_identity(
+        %Data{
+          session_id: session_id,
+          revision: revision,
+          lease: %Lease{lease_id: lease_id, request_id: request_id},
+          snapshots: snapshots
+        },
+        %Snapshot{
+          snapshot_id: snapshot_id,
+          turn_state: %{request: %Turn.Request{request_id: request_id}}
+        }
+      )
+      when is_binary(session_id) and is_integer(revision) and revision >= 0 and
+             is_binary(lease_id) and is_binary(request_id) and is_binary(snapshot_id) do
+    if Enum.any?(snapshots, &checkpoint_snapshot?(&1, snapshot_id, request_id)) do
+      {:ok,
+       %{
+         session_id: session_id,
+         durable_revision: revision,
+         request_id: request_id,
+         lease_id: lease_id,
+         snapshot_id: snapshot_id
+       }}
+    else
+      {:error, {:checkpoint_identity_not_committed, session_id, revision, request_id, lease_id, snapshot_id}}
+    end
+  end
+
+  def checkpoint_identity(%Data{} = session, %Snapshot{} = snapshot) do
+    {:error,
+     {:checkpoint_identity_mismatch, session.session_id, session.revision, checkpoint_lease_id(session),
+      checkpoint_request_id(snapshot), snapshot.snapshot_id}}
   end
 
   @doc "Claims a session for one new request and rejects concurrent use."
@@ -263,6 +319,23 @@ defmodule Jidoka.Session.Store do
       _clock -> System.system_time(:millisecond)
     end
   end
+
+  defp checkpoint_snapshot?(
+         %Snapshot{snapshot_id: snapshot_id, turn_state: %{request: %Turn.Request{request_id: request_id}}},
+         snapshot_id,
+         request_id
+       ),
+       do: true
+
+  defp checkpoint_snapshot?(_snapshot, _snapshot_id, _request_id), do: false
+
+  defp checkpoint_lease_id(%Data{lease: %Lease{lease_id: lease_id}}), do: lease_id
+  defp checkpoint_lease_id(%Data{}), do: nil
+
+  defp checkpoint_request_id(%Snapshot{turn_state: %{request: %Turn.Request{request_id: request_id}}}),
+    do: request_id
+
+  defp checkpoint_request_id(%Snapshot{}), do: nil
 
   defp normalize_store({module, opts}) when is_atom(module) and is_list(opts), do: {module, opts}
   defp normalize_store(module) when is_atom(module), do: {module, []}

--- a/lib/jidoka/session/transitions.ex
+++ b/lib/jidoka/session/transitions.ex
@@ -3,7 +3,10 @@ defmodule Jidoka.Session.Transitions do
   Pure durable session state transitions.
 
   This module validates revisions, leases, claims, checkpoints, commits, and
-  recovery. It does not call a store or another external service.
+  recovery. It does not call a store or another external service. Custom
+  durable stores use these public functions inside one backend transaction,
+  persist the returned `Jidoka.Session.Data`, make that transaction durable,
+  and only then send a successful callback reply.
   """
 
   alias Jidoka.Session.Data

--- a/test/jidoka/custom_file_store_conformance_test.exs
+++ b/test/jidoka/custom_file_store_conformance_test.exs
@@ -1,0 +1,346 @@
+defmodule Jidoka.CustomFileStoreConformanceTest do
+  use ExUnit.Case, async: false
+
+  alias Jidoka.Agent
+  alias Jidoka.Agent.Spec.Controls
+  alias Jidoka.Agent.Spec.Operation
+  alias Jidoka.Effect
+  alias Jidoka.Error.ExecutionError
+  alias Jidoka.Runtime.LocalOperations
+  alias Jidoka.Session.Data
+  alias Jidoka.Session.Lease
+  alias Jidoka.Session.Store
+  alias Jidoka.Snapshot
+  alias Jidoka.TestSupport.FileSessionStore
+  alias Jidoka.Turn
+
+  import Jidoka.TestSupport, only: [count_results: 2, final_llm: 1]
+
+  setup do
+    path = Path.join(System.tmp_dir!(), "jidoka-custom-store-#{System.unique_integer([:positive])}.bin")
+
+    on_exit(fn ->
+      File.rm(path)
+      File.rm(path <> ".next")
+    end)
+
+    %{path: path}
+  end
+
+  test "the public transition set commits lease and checkpoint identities", %{path: path} do
+    {pid, store} = start_store(path)
+    source = start_data("custom-lifecycle")
+    request = Turn.Request.new!(input: "Persist", request_id: "request-lifecycle")
+
+    assert {:ok, ^source} = Store.put_session(store, source)
+
+    assert {:ok, %Data{revision: 1, lease: %Lease{lease_id: "lease-one"}} = claimed} =
+             Store.claim_session(store, source.session_id, request,
+               clock: fn -> 100 end,
+               lease_ttl_ms: 50,
+               owner_id: "worker-one",
+               id_generator: id_generator("lease-one")
+             )
+
+    snapshot = snapshot(claimed, "snapshot-lifecycle")
+
+    assert {:ok, %Data{revision: 2} = checkpointed} =
+             Store.checkpoint_session(store, source.session_id, "lease-one", snapshot,
+               clock: fn -> 110 end,
+               lease_ttl_ms: 50
+             )
+
+    assert {:ok,
+            %{
+              session_id: "custom-lifecycle",
+              durable_revision: 2,
+              request_id: "request-lifecycle",
+              lease_id: "lease-one",
+              snapshot_id: "snapshot-lifecycle"
+            }} = Store.checkpoint_identity(checkpointed, snapshot)
+
+    uncommitted = %Snapshot{snapshot | snapshot_id: "snapshot-uncommitted"}
+
+    assert {:error,
+            {:checkpoint_identity_not_committed, "custom-lifecycle", 2, "request-lifecycle", "lease-one",
+             "snapshot-uncommitted"}} = Store.checkpoint_identity(checkpointed, uncommitted)
+
+    assert {:ok, %Data{revision: 3, lease: %Lease{expires_at_ms: 170}}} =
+             Store.renew_session(store, source.session_id, "lease-one",
+               clock: fn -> 120 end,
+               lease_ttl_ms: 50
+             )
+
+    GenServer.stop(pid)
+
+    {restarted_pid, restarted_store} = start_store(path)
+
+    assert {:ok, %Data{revision: 3, snapshots: [%Snapshot{snapshot_id: "snapshot-lifecycle"}]}} =
+             Store.get_session(restarted_store, source.session_id)
+
+    assert {:ok, %Data{revision: 4, lease: %Lease{lease_id: "lease-two"}} = recovered} =
+             Store.recover_session(restarted_store, source.session_id,
+               clock: fn -> 170 end,
+               lease_ttl_ms: 50,
+               owner_id: "worker-two",
+               id_generator: id_generator("lease-two")
+             )
+
+    assert {:error, {:stale_session_lease, "custom-lifecycle", "lease-one"}} =
+             Store.commit_session(
+               restarted_store,
+               source.session_id,
+               "lease-one",
+               Data.put_error(recovered, :stale),
+               clock: fn -> 171 end
+             )
+
+    assert {:ok, %Data{revision: 5, lease: nil, status: :error}} =
+             Store.commit_session(
+               restarted_store,
+               source.session_id,
+               "lease-two",
+               Data.put_error(recovered, :recovered),
+               clock: fn -> 171 end
+             )
+
+    GenServer.stop(restarted_pid)
+  end
+
+  test "a synced transition survives a store crash before its reply", %{path: path} do
+    test_pid = self()
+    {pid, store} = start_store(path)
+    Process.unlink(pid)
+
+    source = start_data("custom-crash-before-reply")
+    request = Turn.Request.new!(input: "Commit before reply", request_id: "request-crash")
+    assert {:ok, ^source} = Store.put_session(store, source)
+
+    store_ref = Process.monitor(pid)
+
+    {caller, caller_ref} =
+      spawn_monitor(fn ->
+        Store.claim_session(store, source.session_id, request,
+          clock: fn -> 200 end,
+          lease_ttl_ms: 50,
+          owner_id: "crash-worker",
+          id_generator: id_generator("lease-crash"),
+          test_pid: test_pid,
+          crash_after_sync: true
+        )
+      end)
+
+    assert_receive {:file_session_store_synced, :claim, %Data{revision: 1}}, 1_000
+    assert_receive {:DOWN, ^caller_ref, :process, ^caller, _reason}, 1_000
+    assert_receive {:DOWN, ^store_ref, :process, ^pid, :killed}, 1_000
+
+    {restarted_pid, restarted_store} = start_store(path)
+
+    assert {:ok,
+            %Data{
+              revision: 1,
+              status: :running,
+              lease: %Lease{lease_id: "lease-crash", request_id: "request-crash"}
+            }} = Store.get_session(restarted_store, source.session_id)
+
+    GenServer.stop(restarted_pid)
+  end
+
+  test "the file store resumes and forks through public session APIs", %{path: path} do
+    {pid, store} = start_store(path)
+
+    assert {:ok, %Data{}} = Jidoka.Session.start(chat_spec(), "custom-fork-source", store: store)
+
+    assert {:hibernate, source, %Snapshot{} = snapshot} =
+             Jidoka.Session.run("custom-fork-source", "Choose a path",
+               store: store,
+               request_id: "request-fork",
+               llm: final_llm("unused"),
+               checkpoint: :after_prompt
+             )
+
+    assert {:ok, branch} =
+             Jidoka.Session.fork("custom-fork-source",
+               store: store,
+               session_id: "custom-fork-branch",
+               fork_snapshot_id: "snapshot-fork-branch",
+               clock: fn -> 300 end
+             )
+
+    assert branch.lineage.source_snapshot_id == snapshot.snapshot_id
+    assert {:ok, ^source} = Store.get_session(store, "custom-fork-source")
+
+    assert {:ok, source_finished, %Turn.Result{content: "source path"}} =
+             Jidoka.Session.resume("custom-fork-source", store: store, llm: final_llm("source path"))
+
+    assert {:ok, branch_finished, %Turn.Result{content: "branch path"}} =
+             Jidoka.Session.resume("custom-fork-branch", store: store, llm: final_llm("branch path"))
+
+    assert source_finished.session_id == "custom-fork-source"
+    assert branch_finished.session_id == "custom-fork-branch"
+    GenServer.stop(pid)
+  end
+
+  test "the file store preserves an unsafe intent and recovery does not repeat it", %{path: path} do
+    test_pid = self()
+    {:ok, clock} = Elixir.Agent.start_link(fn -> 1_000 end)
+    {pid, store} = start_store(path)
+
+    assert {:ok, %Data{}} = Jidoka.Session.start(unsafe_spec(), "custom-unsafe", store: store)
+
+    operations =
+      LocalOperations.operations(%{
+        refund_order: fn _intent, _journal, _context ->
+          send(test_pid, {:unsafe_operation_started, self()})
+
+          receive do
+            :finish -> {:ok, %{"refund_id" => "unexpected"}}
+          end
+        end
+      })
+
+    worker =
+      Task.async(fn ->
+        Jidoka.Session.run("custom-unsafe", "Refund order_123",
+          store: store,
+          llm: unsafe_llm(),
+          operations: operations,
+          clock: current_clock(clock),
+          lease_ttl_ms: 100,
+          lease_heartbeat: false,
+          owner_id: "unsafe-worker-one"
+        )
+      end)
+
+    assert_receive {:unsafe_operation_started, operation_pid}, 1_000
+    operation_ref = Process.monitor(operation_pid)
+    assert nil == Task.shutdown(worker, :brutal_kill)
+    assert_receive {:DOWN, ^operation_ref, :process, ^operation_pid, _reason}, 1_000
+
+    assert {:ok, %Data{status: :running, snapshots: snapshots}} = Store.get_session(store, "custom-unsafe")
+    assert incomplete_unsafe_intent?(List.last(snapshots))
+
+    Elixir.Agent.update(clock, fn _now -> 1_100 end)
+
+    assert {:error,
+            %ExecutionError{
+              phase: :effect,
+              details: %{reason: :unsafe_once_incomplete_effect, idempotency: :unsafe_once}
+            }} =
+             Jidoka.Session.recover("custom-unsafe",
+               store: store,
+               llm: unsafe_llm(),
+               operations: fn _intent, _journal, _context ->
+                 send(test_pid, :unsafe_operation_repeated)
+                 {:ok, %{}}
+               end,
+               clock: current_clock(clock),
+               lease_ttl_ms: 100,
+               lease_heartbeat: false,
+               owner_id: "unsafe-worker-two"
+             )
+
+    refute_received :unsafe_operation_repeated
+    GenServer.stop(pid)
+  end
+
+  test "durable schema and codec documents match the public accessors" do
+    session_version = Data.schema_version()
+    session_supported = inspect(Data.supported_schema_versions())
+    snapshot_version = Snapshot.schema_version()
+    snapshot_supported = inspect(Snapshot.supported_schema_versions())
+    prefix = Snapshot.serialization_prefix()
+
+    sessions = guide("sessions-and-stores.md")
+    snapshots = guide("runtime-capabilities-internals.md")
+    durability = guide("runtime-and-harness.md")
+
+    assert sessions =~ "`schema_version/0` is `#{session_version}`"
+    assert sessions =~ "`supported_schema_versions/0` is `#{session_supported}`"
+    assert snapshots =~ "`Jidoka.Snapshot.schema_version/0` returns `#{snapshot_version}`"
+    assert snapshots =~ "`supported_schema_versions/0` returns `#{snapshot_supported}`"
+    assert durability =~ "`Jidoka.Snapshot.schema_version() == #{snapshot_version}`"
+    assert durability =~ "`Jidoka.Snapshot.serialization_prefix() == \"#{prefix}\"`"
+    assert durability =~ "`Jidoka.Session.Data.schema_version() == #{session_version}`"
+  end
+
+  defp start_store(path) do
+    {:ok, pid} = FileSessionStore.start_link(path: path)
+    {pid, {FileSessionStore, pid: pid}}
+  end
+
+  defp start_data(session_id) do
+    {:ok, session} = Data.start(chat_spec(), session_id: session_id)
+    session
+  end
+
+  defp snapshot(%Data{} = session, snapshot_id) do
+    request = List.last(session.requests)
+
+    Turn.State.new!(
+      spec: session.spec,
+      plan: Turn.Plan.new!(session.spec),
+      request: request,
+      agent_state: request.agent_state
+    )
+    |> Snapshot.from_turn_state!(Turn.Cursor.after_prompt(), snapshot_id: snapshot_id)
+  end
+
+  defp chat_spec do
+    Agent.Spec.new!(
+      id: "custom_file_store_agent",
+      instructions: "Test the public durable store contract.",
+      model: %{provider: :test, id: "model"}
+    )
+  end
+
+  defp unsafe_spec do
+    Agent.Spec.new!(
+      id: "custom_file_store_unsafe_agent",
+      instructions: "Use refund_order, then report the result.",
+      model: %{provider: :test, id: "model"},
+      operations: [
+        Operation.new!(
+          name: "refund_order",
+          description: "Starts one refund.",
+          idempotency: :unsafe_once
+        )
+      ],
+      controls:
+        Controls.new!(
+          operations: [
+            %{control: Jidoka.IntegrationSupport.ApprovalControl, match: %{name: "refund_order"}}
+          ]
+        ),
+      runtime_defaults: %{max_model_turns: 4}
+    )
+  end
+
+  defp unsafe_llm do
+    fn _intent, %Effect.Journal{} = journal, _context ->
+      case count_results(journal, :llm) do
+        0 ->
+          {:ok,
+           %{
+             type: :operation,
+             name: "refund_order",
+             arguments: %{"order_id" => "order_123"}
+           }}
+
+        _count ->
+          {:ok, %{type: :final, content: "Refund complete."}}
+      end
+    end
+  end
+
+  defp incomplete_unsafe_intent?(%Snapshot{} = snapshot) do
+    Enum.any?(snapshot.turn_state.journal.intents, fn {_id, intent} ->
+      intent.kind == :operation and intent.idempotency == :unsafe_once and
+        is_nil(Effect.Journal.result_for(snapshot.turn_state.journal, intent))
+    end)
+  end
+
+  defp guide(name), do: File.read!(Path.expand("../../guides/#{name}", __DIR__))
+  defp id_generator(id), do: fn "lease" -> id end
+  defp current_clock(clock), do: fn -> Elixir.Agent.get(clock, & &1) end
+end

--- a/test/jidoka/harness_session_test.exs
+++ b/test/jidoka/harness_session_test.exs
@@ -69,7 +69,10 @@ defmodule Jidoka.HarnessSessionTest do
   end
 
   defmodule ResumeOnlyStore do
-    def claim_resume(_session_id, _opts), do: {:error, :not_called}
+    def claim_resume(_session_id, opts) do
+      if test_pid = Keyword.get(opts, :test_pid), do: send(test_pid, :partial_resume_store_called)
+      {:error, :not_called}
+    end
   end
 
   defmodule RecoverOnlyStore do
@@ -212,6 +215,11 @@ defmodule Jidoka.HarnessSessionTest do
              Store.claim_session(store, "partial-store-session", request)
 
     refute_receive :partial_store_called
+
+    assert {:error, {:partial_durable_session_store, ResumeOnlyStore, [claim_resume: 2], _missing}} =
+             Store.claim_resume({ResumeOnlyStore, test_pid: self()}, "partial-store-session")
+
+    refute_receive :partial_resume_store_called
   end
 
   test "sessions collect snapshots and pending review requests" do

--- a/test/support/file_session_store.ex
+++ b/test/support/file_session_store.ex
@@ -1,0 +1,189 @@
+defmodule Jidoka.TestSupport.FileSessionStore do
+  @moduledoc false
+
+  use GenServer
+
+  @behaviour Jidoka.Session.Store
+
+  alias Jidoka.Session.Data
+  alias Jidoka.Session.Transitions
+  alias Jidoka.Snapshot
+  alias Jidoka.Turn
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) when is_list(opts) do
+    GenServer.start_link(__MODULE__, opts, Keyword.take(opts, [:name]))
+  end
+
+  @impl true
+  def init(opts) do
+    path = opts |> Keyword.fetch!(:path) |> Path.expand()
+
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         {:ok, sessions} <- load(path) do
+      {:ok, %{path: path, sessions: sessions}}
+    end
+  end
+
+  @impl true
+  def put_session(%Data{} = session, opts), do: call(opts, {:put, session, runtime_opts(opts)})
+
+  @impl true
+  def get_session(session_id, opts) when is_binary(session_id), do: call(opts, {:get, session_id})
+
+  @impl true
+  def list_sessions(opts), do: call(opts, :list)
+
+  @impl true
+  def claim_session(session_id, %Turn.Request{} = request, opts) when is_binary(session_id) do
+    transition(opts, :claim, session_id, &Transitions.claim(&1, request, opts))
+  end
+
+  @impl true
+  def claim_resume(session_id, opts) when is_binary(session_id) do
+    transition(opts, :resume, session_id, &Transitions.resume(&1, opts))
+  end
+
+  @impl true
+  def recover_session(session_id, opts) when is_binary(session_id) do
+    transition(opts, :recover, session_id, &Transitions.recover(&1, opts))
+  end
+
+  @impl true
+  def checkpoint_session(session_id, lease_id, %Snapshot{} = snapshot, opts)
+      when is_binary(session_id) and is_binary(lease_id) do
+    transition(opts, :checkpoint, session_id, &Transitions.checkpoint(&1, lease_id, snapshot, opts))
+  end
+
+  @impl true
+  def commit_session(session_id, lease_id, %Data{} = completed, opts)
+      when is_binary(session_id) and is_binary(lease_id) do
+    transition(opts, :commit, session_id, &Transitions.commit(&1, lease_id, completed, opts))
+  end
+
+  @impl true
+  def renew_session(session_id, lease_id, opts) when is_binary(session_id) and is_binary(lease_id) do
+    transition(opts, :renew, session_id, &Transitions.renew(&1, lease_id, opts))
+  end
+
+  @impl true
+  def handle_call({:put, %Data{} = incoming, opts}, _from, state) do
+    current = Map.get(state.sessions, incoming.session_id)
+
+    result =
+      with {:ok, %Data{} = updated} <- Transitions.put(current, incoming) do
+        persist(state, updated, :put, opts)
+      end
+
+    {:reply, result, put_committed(state, result)}
+  end
+
+  def handle_call({:get, session_id}, _from, state) do
+    result =
+      case Map.fetch(state.sessions, session_id) do
+        {:ok, %Data{} = session} -> {:ok, session}
+        :error -> {:error, {:session_not_found, session_id}}
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call(:list, _from, state) do
+    sessions = state.sessions |> Map.values() |> Enum.sort_by(& &1.session_id)
+    {:reply, {:ok, sessions}, state}
+  end
+
+  def handle_call({:transition, operation, session_id, transition, opts}, _from, state) do
+    result =
+      with {:ok, %Data{} = current} <- fetch(state.sessions, session_id),
+           {:ok, %Data{} = updated} <- transition.(current) do
+        persist(state, updated, operation, opts)
+      end
+
+    {:reply, result, put_committed(state, result)}
+  end
+
+  defp transition(opts, operation, session_id, transition) when is_function(transition, 1) do
+    call(opts, {:transition, operation, session_id, transition, runtime_opts(opts)})
+  end
+
+  defp persist(state, %Data{} = updated, operation, opts) do
+    sessions = Map.put(state.sessions, updated.session_id, updated)
+    temporary = state.path <> ".next"
+    binary = :erlang.term_to_binary(sessions, [:deterministic])
+
+    _result = File.rm(temporary)
+
+    with :ok <- write_synced(temporary, binary),
+         :ok <- File.chmod(temporary, 0o600),
+         :ok <- File.rename(temporary, state.path) do
+      notify_synced(opts, operation, updated)
+      maybe_crash_after_sync(opts)
+      {:ok, updated}
+    end
+  end
+
+  defp write_synced(path, binary) do
+    case File.open(path, [:write, :binary, :exclusive]) do
+      {:ok, io} ->
+        try do
+          :ok = IO.binwrite(io, binary)
+          :file.sync(io)
+        after
+          File.close(io)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp load(path) do
+    case File.read(path) do
+      {:ok, binary} -> decode_sessions(binary)
+      {:error, :enoent} -> {:ok, %{}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp decode_sessions(binary) do
+    case :erlang.binary_to_term(binary, [:safe]) do
+      sessions when is_map(sessions) -> {:ok, sessions}
+      _value -> {:error, :invalid_file_session_store}
+    end
+  rescue
+    ArgumentError -> {:error, :invalid_file_session_store}
+  end
+
+  defp fetch(sessions, session_id) do
+    case Map.fetch(sessions, session_id) do
+      {:ok, %Data{} = session} -> {:ok, session}
+      :error -> {:error, {:session_not_found, session_id}}
+    end
+  end
+
+  defp put_committed(state, {:ok, %Data{} = session}) do
+    %{state | sessions: Map.put(state.sessions, session.session_id, session)}
+  end
+
+  defp put_committed(state, _result), do: state
+
+  defp notify_synced(opts, operation, session) do
+    case Keyword.get(opts, :test_pid) do
+      pid when is_pid(pid) -> send(pid, {:file_session_store_synced, operation, session})
+      _pid -> :ok
+    end
+  end
+
+  defp maybe_crash_after_sync(opts) do
+    if Keyword.get(opts, :crash_after_sync, false), do: Process.exit(self(), :kill)
+  end
+
+  defp runtime_opts(opts), do: Keyword.take(opts, [:test_pid, :crash_after_sync])
+
+  defp call(opts, message) do
+    opts
+    |> Keyword.fetch!(:pid)
+    |> GenServer.call(message, Keyword.get(opts, :call_timeout, 5_000))
+  end
+end


### PR DESCRIPTION
## Summary
- expose one stable committed checkpoint identity from public session data
- document the public custom-store transaction boundary and correct stale schema versions
- add a reusable synced file-store fixture with lifecycle, crash, recovery, unsafe-effect, and fork conformance tests
- prove partial durable stores fail before both claim and resume callbacks

## Verification
- mix test (831 passed, 42 excluded)
- mix test --include parity test/parity/crash_safe_durable_execution_test.exs test/parity/safe_session_fork_test.exs test/jidoka/harness_store_durability_test.exs test/jidoka/session_atomic_continuation_test.exs test/jidoka/session_execution_environment_test.exs test/jidoka/session_memory_commit_order_test.exs test/jidoka/stabilization_contract_test.exs (43 passed)
- mix credo --min-priority higher
- mix dialyzer
- mix doctor --raise
- mix docs --warnings-as-errors
- mix run scripts/check_docs.exs

Beadwork: jido_console-m3e04