### PR TITLE
Keep the encoded turn contract stable across steps of a turn

### DIFF
--- a/lib/jidoka/adapter/req_llm/prompt_adapter.ex
+++ b/lib/jidoka/adapter/req_llm/prompt_adapter.ex
@@ -16,6 +16,18 @@ defmodule Jidoka.Adapter.ReqLLM.PromptAdapter do
         prompt
         |> Map.delete(:messages)
         |> Map.delete("messages")
+        # `loop_index` is runtime bookkeeping, not an instruction to the model,
+        # and it is the one key here that changes on every step of a turn. Because
+        # this contract is encoded into a system message that precedes every other
+        # message, leaving it in makes the request's leading bytes differ each
+        # step, which defeats provider prompt caching for the whole prefix behind
+        # it - the agent instructions and the user message included. The runtime
+        # keeps its own copy: `Spine.Steps.plan_model_effect/1` puts `loop_index`
+        # in the effect payload and names it in the idempotency key, and
+        # `Turn.Result`'s debug metadata still reads it off the prompt map, so
+        # dropping it here costs no behaviour.
+        |> Map.delete(:loop_index)
+        |> Map.delete("loop_index")
         |> Jason.encode!()
 
       messages =

--- a/test/jidoka/runtime/req_llm/prompt_adapter_test.exs
+++ b/test/jidoka/runtime/req_llm/prompt_adapter_test.exs
@@ -191,4 +191,43 @@ defmodule Jidoka.Adapter.ReqLLM.PromptAdapterTest do
   end
 
   defp text(message), do: Enum.map_join(message.content, & &1.text)
+
+  alias Jidoka.Adapter.ReqLLM.PromptAdapter
+
+  defp system_texts(prompt) do
+    {:ok, messages} = PromptAdapter.build(prompt)
+
+    messages
+    |> Enum.filter(&(&1.role == :system))
+    |> Enum.map(fn message -> Enum.map_join(message.content, "", & &1.text) end)
+  end
+
+  defp contract_prompt(extra) do
+    Map.merge(%{messages: [%{role: :user, content: "hello"}]}, extra)
+  end
+
+  # WHY THIS TEST EXISTS: the encoded contract rides in a system message that
+  # precedes every other message, so any key that changes per step makes the
+  # request's leading bytes differ each step and defeats provider prompt caching
+  # for the entire prefix behind it. `loop_index` was the only such key.
+  test "the encoded contract is byte-identical across steps of a turn" do
+    assert system_texts(contract_prompt(%{loop_index: 0})) ==
+             system_texts(contract_prompt(%{loop_index: 7}))
+  end
+
+  test "a string-keyed loop_index is excluded too" do
+    assert system_texts(contract_prompt(%{"loop_index" => 0})) ==
+             system_texts(contract_prompt(%{"loop_index" => 3}))
+  end
+
+  # WHY THIS TEST EXISTS: excluding one key must not silence the rest of the
+  # contract, which the model does act on.
+  test "the remaining contract keys still reach the model" do
+    [_runtime, contract] =
+      system_texts(contract_prompt(%{loop_index: 2, result: %{shape: "report"}}))
+
+    assert contract =~ "result"
+    assert contract =~ "report"
+    refute contract =~ "loop_index"
+  end
 end


### PR DESCRIPTION
The turn contract is JSON-encoded into a system message that precedes every other message in the request. It is built from the prompt map, which carries `loop_index`, so the leading bytes of the request differ on every step of a turn.

That defeats provider prompt caching for the entire prefix behind it, because a cached prefix must match byte for byte. The agent instructions and the user message both sit behind that system message, so a caller who sets a cache breakpoint pays the cache-write premium on every step and reads nothing back. For an agent whose prompt leads with a large stable procedure, that is the difference between caching most of the input and caching none of it.

Measured through `PromptAdapter.build/1`:

```
before   loop_index=0 -> "Jidoka turn contract:\n{\"loop_index\":0}"
         loop_index=1 -> "Jidoka turn contract:\n{\"loop_index\":1}"
after    both         -> "Jidoka turn contract:\n{}"
```

`loop_index` is runtime bookkeeping rather than an instruction to the model, so this excludes it from the encoded contract while leaving it on the prompt map. Nothing loses access to it:

- `Spine.Steps.plan_model_effect/1` puts it in the effect payload and names it in the idempotency key, so step identity and dedupe are unchanged.
- `Turn.Result`s debug metadata still reads it from the prompt map.

Both the atom and string keys are excluded, since the map accepts either.

Three tests cover it: the contract is byte-identical across steps for either key form, and the remaining contract keys still reach the model. Full suite passes locally (987 tests, 0 failures).

Happy to adjust the approach if you would rather move the contract message behind the transcript instead, or gate this behind an option — the goal is only that the bytes ahead of a cache breakpoint stop changing per step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jidoka/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790851054&installation_model_id=434874&pr_number=71&repository=agentjido%2Fjidoka&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjidoka%2Fpull%2F71&signature=2ba3b13332c3a1fe34c0045e39da004a66e7b7099b6765ee2baa248b34430662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->